### PR TITLE
feat(authz): RFC 8693 + RFC 9396 token-exchange POC

### DIFF
--- a/service/authorization/v2/authorization.go
+++ b/service/authorization/v2/authorization.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"connectrpc.com/connect"
@@ -81,6 +82,8 @@ func NewRegistration() *serviceregistry.Service[authzV2Connect.AuthorizationServ
 				}
 				l.Debug("authorization service config", slog.Any("config", authZCfg.LogValue()))
 
+				rarHandler := buildRARHandler(as, authZCfg, srp)
+
 				// A file-backed policy snapshot takes precedence over the SDK-backed
 				// cache: it's already in memory, validated at load, and never needs
 				// refresh. The CRUD admin server is responsible for producing the file.
@@ -92,12 +95,12 @@ func NewRegistration() *serviceregistry.Service[authzV2Connect.AuthorizationServ
 					}
 					as.cache = store
 					l.Info("authorization service using file-backed policy provider", slog.String("path", authZCfg.PolicyFile))
-					return as, nil
+					return as, rarHandler
 				}
 
 				if !authZCfg.Cache.Enabled {
 					l.Debug("entitlement policy cache is disabled")
-					return as, nil
+					return as, rarHandler
 				}
 
 				cacheClient, err := srp.NewCacheClient(cache.Options{})
@@ -127,9 +130,43 @@ func NewRegistration() *serviceregistry.Service[authzV2Connect.AuthorizationServ
 					l.Info("direct entitlements are enabled for authorization service")
 				}
 
-				return as, nil
+				return as, rarHandler
 			},
 		},
+	}
+}
+
+// buildRARHandler wires the RFC 8693 + RFC 9396 token-exchange endpoint when
+// enabled. Returns nil when the feature is off, in which case the platform
+// HTTP mux logs a benign "no extra http handlers" message and moves on.
+func buildRARHandler(svc *Service, cfg *Config, srp serviceregistry.RegistrationParams) serviceregistry.HandlerServer {
+	if !cfg.RAR.Enabled {
+		return nil
+	}
+	ttl, err := time.ParseDuration(cfg.RAR.TokenTTL)
+	if err != nil {
+		srp.Logger.Error("invalid rar.token_ttl, falling back to 1h", slog.String("value", cfg.RAR.TokenTTL), slog.Any("error", err))
+		ttl = time.Hour
+	}
+	signer, err := NewEphemeralRARSigner(cfg.RAR.Issuer, ttl)
+	if err != nil {
+		srp.Logger.Error("failed to create rar signer; rar endpoint will be disabled", slog.Any("error", err))
+		return nil
+	}
+	srp.Logger.Info("rar token endpoint enabled",
+		slog.String("issuer", cfg.RAR.Issuer),
+		slog.String("token_ttl", ttl.String()),
+		slog.String("token_path", rarTokenPath),
+		slog.String("jwks_path", rarJWKSPath),
+	)
+	endpoint := &RAREndpoint{
+		pdp:      svc,
+		signer:   signer,
+		verifier: srp.AccessTokenVerifier,
+	}
+	return func(_ context.Context, mux *http.ServeMux) error {
+		endpoint.Mount(mux)
+		return nil
 	}
 }
 

--- a/service/authorization/v2/config.go
+++ b/service/authorization/v2/config.go
@@ -21,6 +21,10 @@ type Config struct {
 	// in-memory snapshot instead of round-tripping to the policy service.
 	PolicyFile string `mapstructure:"policy_file" json:"policy_file"`
 
+	// RAR enables the RFC 8693 + RFC 9396 token-exchange endpoint at
+	// POST /v2/authorization/token. Disabled by default.
+	RAR RARConfig `mapstructure:"rar" json:"rar"`
+
 	// experimental features
 
 	// enable entity direct entitlements that do not require subject mappings
@@ -28,6 +32,15 @@ type Config struct {
 
 	// enforce strict namespaced entitlement evaluation behavior in access decisioning
 	EnforceNamespacedEntitlements bool `mapstructure:"enforce_namespaced_entitlements" json:"enforce_namespaced_entitlements" default:"false"`
+}
+
+// RARConfig controls the RFC 9396 access-token issuance endpoint.
+// The signing key is ephemeral in this POC: process restart rotates it and
+// invalidates outstanding tokens.
+type RARConfig struct {
+	Enabled  bool   `mapstructure:"enabled" json:"enabled" default:"false"`
+	Issuer   string `mapstructure:"issuer" json:"issuer" default:"opentdf-authorization"`
+	TokenTTL string `mapstructure:"token_ttl" json:"token_ttl" default:"1h"`
 }
 
 // Validate tests for a sensible configuration
@@ -65,6 +78,13 @@ func (c *Config) LogValue() slog.Value {
 			),
 		),
 		slog.String("policy_file", c.PolicyFile),
+		slog.Any("rar",
+			slog.GroupValue(
+				slog.Bool("enabled", c.RAR.Enabled),
+				slog.String("issuer", c.RAR.Issuer),
+				slog.String("token_ttl", c.RAR.TokenTTL),
+			),
+		),
 		slog.Bool("allow_direct_entitlements", c.AllowDirectEntitlements),
 		slog.Bool("enforce_namespaced_entitlements", c.EnforceNamespacedEntitlements),
 	)

--- a/service/authorization/v2/rar.go
+++ b/service/authorization/v2/rar.go
@@ -1,0 +1,389 @@
+// Package authorization adds an RFC 8693 token-exchange endpoint that issues
+// access tokens carrying RFC 9396 authorization_details claims. The endpoint
+// is a thin "token decoration" layer: it does NOT implement a full OAuth 2.0
+// Authorization Server — no /authorize, no PKCE, no refresh tokens, no client
+// registration. The caller MUST present a subject token verified by the
+// platform's existing token verifier (i.e. an IdP-issued JWT).
+//
+// Flow per request:
+//
+//  1. Parse RFC 8693 form parameters (grant_type, subject_token,
+//     subject_token_type, requested_token_type, authorization_details).
+//  2. Verify subject_token using the configured AccessTokenVerifier.
+//  3. For each authorization_details entry, fan out to the existing v2 PDP.
+//     Only (action, location) combinations the PDP permits make it into the
+//     issued token.
+//  4. Mint and sign a JWT with the granted authorization_details, return as
+//     application/json per RFC 8693 §2.2.
+//
+// The issuer's signing key is ephemeral by default — restarting the process
+// invalidates outstanding tokens. The public JWKS is exposed at the companion
+// endpoint so resource servers can verify.
+package authorization
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	authzV2 "github.com/opentdf/platform/protocol/go/authorization/v2"
+	"github.com/opentdf/platform/protocol/go/entity"
+	"github.com/opentdf/platform/protocol/go/policy"
+	authn "github.com/opentdf/platform/service/internal/auth"
+	"github.com/opentdf/platform/service/logger/audit"
+	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
+)
+
+const (
+	// RFC 8693 grant type
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	// RFC 8693 token types
+	tokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
+	tokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
+	tokenTypeIDToken     = "urn:ietf:params:oauth:token-type:id_token"
+
+	// Custom RAR detail type understood by this POC. Other type values cause
+	// the detail to be rejected at validation time.
+	detailTypeOpenTDFAttribute = "opentdf_attribute"
+
+	rarTokenPath = "/v2/authorization/token"
+	rarJWKSPath  = "/v2/authorization/jwks.json"
+)
+
+// AuthorizationDetail mirrors the RFC 9396 object. Only the fields meaningful
+// to the POC are typed; unknown keys round-trip via UnknownFields so policy
+// authors can add metadata without us silently dropping it.
+type AuthorizationDetail struct {
+	Type          string         `json:"type"`
+	Actions       []string       `json:"actions,omitempty"`
+	Locations     []string       `json:"locations,omitempty"`
+	Datatypes     []string       `json:"datatypes,omitempty"`
+	Identifier    string         `json:"identifier,omitempty"`
+	Privileges    []string       `json:"privileges,omitempty"`
+	UnknownFields map[string]any `json:"-"`
+}
+
+// tokenExchangeResponse follows RFC 8693 §2.2.
+type tokenExchangeResponse struct {
+	AccessToken          string                 `json:"access_token"`
+	IssuedTokenType      string                 `json:"issued_token_type"`
+	TokenType            string                 `json:"token_type"`
+	ExpiresIn            int64                  `json:"expires_in"`
+	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"`
+}
+
+// rarErrorResponse follows RFC 6749 §5.2.
+type rarErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// RAREndpoint owns the dependencies for the token issuance flow. The PDP
+// dependency is the same Service that hosts GetDecision*, so policy reuse is
+// implicit — no second copy of the entitlement store.
+type RAREndpoint struct {
+	pdp      *Service
+	signer   *RARSigner
+	verifier authn.AccessTokenVerifier
+}
+
+// Mount attaches the RAR token + JWKS handlers to the supplied mux.
+func (r *RAREndpoint) Mount(mux *http.ServeMux) {
+	mux.HandleFunc("POST "+rarTokenPath, r.handleToken)
+	mux.HandleFunc("GET "+rarJWKSPath, r.handleJWKS)
+}
+
+func (r *RAREndpoint) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	if r.signer == nil {
+		writeError(w, http.StatusServiceUnavailable, "server_error", "rar signer not configured")
+		return
+	}
+	w.Header().Set("Content-Type", "application/jwk-set+json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if err := json.NewEncoder(w).Encode(r.signer.JWKS()); err != nil {
+		// Already wrote the header; nothing useful to do but log.
+		r.pdp.logger.Error("failed to encode JWKS", slog.Any("error", err))
+	}
+}
+
+func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	if r.signer == nil {
+		writeError(w, http.StatusServiceUnavailable, "server_error", "rar signer not configured")
+		return
+	}
+	if err := req.ParseForm(); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "could not parse form: "+err.Error())
+		return
+	}
+	if got := req.PostForm.Get("grant_type"); got != grantTypeTokenExchange {
+		writeError(w, http.StatusBadRequest, "unsupported_grant_type",
+			fmt.Sprintf("expected %q, got %q", grantTypeTokenExchange, got))
+		return
+	}
+	subjectToken := req.PostForm.Get("subject_token")
+	if subjectToken == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "subject_token is required")
+		return
+	}
+	subjectTokenType := req.PostForm.Get("subject_token_type")
+	switch subjectTokenType {
+	case tokenTypeIDToken, tokenTypeAccessToken:
+		// supported
+	case "":
+		writeError(w, http.StatusBadRequest, "invalid_request", "subject_token_type is required")
+		return
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"unsupported subject_token_type "+subjectTokenType)
+		return
+	}
+	requestedTokenType := req.PostForm.Get("requested_token_type")
+	if requestedTokenType == "" {
+		requestedTokenType = tokenTypeJWT
+	}
+	if requestedTokenType != tokenTypeJWT {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"only "+tokenTypeJWT+" is supported as requested_token_type")
+		return
+	}
+	audience := req.PostForm.Get("audience")
+
+	if r.verifier == nil {
+		writeError(w, http.StatusServiceUnavailable, "server_error",
+			"platform token verifier is not configured")
+		return
+	}
+	verified, err := r.verifier.VerifyAccessToken(ctx, subjectToken)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid_token",
+			"subject_token verification failed: "+err.Error())
+		return
+	}
+
+	// Propagate the verified caller identity into the gRPC metadata the
+	// downstream PDP reads via ctxAuth.GetClientIDFromContext. Without this,
+	// GetDecisionMultiResource fails with "no metadata found within context".
+	subject, _ := verified.Get("sub")
+	subjectStr, _ := subject.(string)
+	if subjectStr == "" {
+		subjectStr = verified.Subject()
+	}
+	clientID := clientIDFromToken(verified)
+	if clientID != "" {
+		ctx = ctxAuth.EnrichIncomingContextMetadataWithAuthn(ctx, r.pdp.logger, clientID)
+	}
+	// The PDP emits audit events through audit.LogAuditEvent which expects an
+	// auditTransaction in context. The normal HTTP/Connect interceptor chain
+	// would set this up; the RAR endpoint installs its own transaction keyed
+	// on the verified subject so that decisions are still audited.
+	actorID := subjectStr
+	if actorID == "" {
+		actorID = clientID
+	}
+	ctx = audit.ContextWithActorID(ctx, actorID)
+
+	requestedDetails, err := parseAuthorizationDetails(req.PostForm.Get("authorization_details"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_authorization_details", err.Error())
+		return
+	}
+	if len(requestedDetails) == 0 {
+		writeError(w, http.StatusBadRequest, "invalid_authorization_details",
+			"at least one authorization_details entry is required")
+		return
+	}
+	for i, d := range requestedDetails {
+		if err := validateDetail(d); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_authorization_details",
+				fmt.Sprintf("entry %d: %s", i, err.Error()))
+			return
+		}
+	}
+
+	granted, err := r.evaluate(ctx, subjectToken, requestedDetails)
+	if err != nil {
+		r.pdp.logger.ErrorContext(ctx, "rar PDP evaluation failed", slog.Any("error", err))
+		writeError(w, http.StatusInternalServerError, "server_error",
+			"policy evaluation failed")
+		return
+	}
+	if len(granted) == 0 {
+		// Nothing was permitted — RFC 9396 §6.1 mandates access_denied.
+		writeError(w, http.StatusForbidden, "access_denied",
+			"none of the requested authorization_details were granted")
+		return
+	}
+
+	signed, exp, err := r.signer.Issue(subjectStr, audience, granted)
+	if err != nil {
+		r.pdp.logger.ErrorContext(ctx, "rar token sign failed", slog.Any("error", err))
+		writeError(w, http.StatusInternalServerError, "server_error", "could not mint access token")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	if err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+		AccessToken:          signed,
+		IssuedTokenType:      tokenTypeJWT,
+		TokenType:            "Bearer",
+		ExpiresIn:            int64(time.Until(exp).Seconds()),
+		AuthorizationDetails: granted,
+	}); err != nil {
+		r.pdp.logger.Error("failed to encode rar response", slog.Any("error", err))
+	}
+}
+
+// evaluate fans the requested details out to the existing v2 PDP and returns
+// only the (action, location) combinations that PERMIT.
+func (r *RAREndpoint) evaluate(ctx context.Context, subjectToken string, requested []AuthorizationDetail) ([]AuthorizationDetail, error) {
+	granted := make([]AuthorizationDetail, 0, len(requested))
+	for _, detail := range requested {
+		grantedActions := make([]string, 0, len(detail.Actions))
+		grantedLocations := make(map[string]struct{})
+		for _, actionName := range detail.Actions {
+			permitted, err := r.decideAction(ctx, subjectToken, actionName, detail.Locations)
+			if err != nil {
+				return nil, fmt.Errorf("action %q: %w", actionName, err)
+			}
+			if len(permitted) == 0 {
+				continue
+			}
+			grantedActions = append(grantedActions, actionName)
+			for _, loc := range permitted {
+				grantedLocations[loc] = struct{}{}
+			}
+		}
+		if len(grantedActions) == 0 {
+			continue
+		}
+		locations := make([]string, 0, len(grantedLocations))
+		// Preserve request order — RFC 9396 is silent on ordering, but
+		// stability makes the response predictable.
+		for _, loc := range detail.Locations {
+			if _, ok := grantedLocations[loc]; ok {
+				locations = append(locations, loc)
+			}
+		}
+		grantedDetail := detail
+		grantedDetail.Actions = grantedActions
+		grantedDetail.Locations = locations
+		granted = append(granted, grantedDetail)
+	}
+	return granted, nil
+}
+
+func (r *RAREndpoint) decideAction(ctx context.Context, subjectToken, actionName string, locations []string) ([]string, error) {
+	if len(locations) == 0 {
+		return nil, nil
+	}
+	resources := make([]*authzV2.Resource, 0, len(locations))
+	for i, loc := range locations {
+		resources = append(resources, &authzV2.Resource{
+			EphemeralId: fmt.Sprintf("loc-%d", i),
+			Resource: &authzV2.Resource_AttributeValues_{
+				AttributeValues: &authzV2.Resource_AttributeValues{
+					Fqns: []string{loc},
+				},
+			},
+		})
+	}
+	req := connect.NewRequest(&authzV2.GetDecisionMultiResourceRequest{
+		EntityIdentifier: &authzV2.EntityIdentifier{
+			Identifier: &authzV2.EntityIdentifier_Token{
+				Token: &entity.Token{
+					EphemeralId: "rar-subject",
+					Jwt:         subjectToken,
+				},
+			},
+		},
+		Action:    &policy.Action{Name: actionName},
+		Resources: resources,
+	})
+	resp, err := r.pdp.GetDecisionMultiResource(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	permitted := make([]string, 0, len(resources))
+	for i, rd := range resp.Msg.GetResourceDecisions() {
+		if rd.GetDecision() == authzV2.Decision_DECISION_PERMIT {
+			permitted = append(permitted, locations[i])
+		}
+	}
+	return permitted, nil
+}
+
+// parseAuthorizationDetails decodes the RFC 9396 array — accepted as either a
+// JSON array literal or a JSON-encoded string (browsers tend to URL-encode it
+// either way, but the body parser already URL-decoded).
+func parseAuthorizationDetails(raw string) ([]AuthorizationDetail, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var details []AuthorizationDetail
+	if err := json.Unmarshal([]byte(raw), &details); err != nil {
+		// Try unwrapping one layer of JSON-string-ification (some clients
+		// double-encode when stuffing into form bodies).
+		var inner string
+		if jerr := json.Unmarshal([]byte(raw), &inner); jerr == nil {
+			if err2 := json.Unmarshal([]byte(inner), &details); err2 == nil {
+				return details, nil
+			}
+		}
+		return nil, fmt.Errorf("could not decode authorization_details: %w", err)
+	}
+	return details, nil
+}
+
+func validateDetail(d AuthorizationDetail) error {
+	if d.Type == "" {
+		return errors.New("type is required")
+	}
+	if d.Type != detailTypeOpenTDFAttribute {
+		return fmt.Errorf("unsupported type %q (expected %q)", d.Type, detailTypeOpenTDFAttribute)
+	}
+	if len(d.Actions) == 0 {
+		return errors.New("actions is required")
+	}
+	if len(d.Locations) == 0 {
+		return errors.New("locations is required")
+	}
+	return nil
+}
+
+// clientIDFromToken pulls the OAuth client identifier from the verified
+// subject token, falling back to the subject claim when client_id is absent
+// (some IdPs only set "azp" or omit it for user-flow tokens).
+func clientIDFromToken(verified jwtToken) string {
+	for _, claim := range []string{"client_id", "azp"} {
+		if v, ok := verified.Get(claim); ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return verified.Subject()
+}
+
+// jwtToken is the surface area of jwt.Token actually used here; declaring it
+// locally lets the test substitute a lightweight stub without pulling jwx in.
+type jwtToken interface {
+	Get(string) (any, bool)
+	Subject() string
+}
+
+func writeError(w http.ResponseWriter, status int, code, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(rarErrorResponse{Error: code, ErrorDescription: description})
+}

--- a/service/authorization/v2/rar.go
+++ b/service/authorization/v2/rar.go
@@ -40,13 +40,15 @@ import (
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 )
 
+// IANA-registered URIs from RFC 8693 — these are public identifiers, not
+// credentials, but gosec G101 keyword-matches "token" / "grant-type" and
+// flags them, hence the per-line nolint annotations below.
 const (
-	// RFC 8693 grant type
-	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
-	// RFC 8693 token types
-	tokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
-	tokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
-	tokenTypeIDToken     = "urn:ietf:params:oauth:token-type:id_token"
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // RFC 8693 IANA URI
+
+	tokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"          //nolint:gosec // RFC 8693 IANA URI
+	tokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token" //nolint:gosec // RFC 8693 IANA URI
+	tokenTypeIDToken     = "urn:ietf:params:oauth:token-type:id_token"     //nolint:gosec // RFC 8693 IANA URI
 
 	// Custom RAR detail type understood by this POC. Other type values cause
 	// the detail to be rejected at validation time.
@@ -71,10 +73,10 @@ type AuthorizationDetail struct {
 
 // tokenExchangeResponse follows RFC 8693 §2.2.
 type tokenExchangeResponse struct {
-	AccessToken          string                 `json:"access_token"`
-	IssuedTokenType      string                 `json:"issued_token_type"`
-	TokenType            string                 `json:"token_type"`
-	ExpiresIn            int64                  `json:"expires_in"`
+	AccessToken          string                `json:"access_token"`
+	IssuedTokenType      string                `json:"issued_token_type"`
+	TokenType            string                `json:"token_type"`
+	ExpiresIn            int64                 `json:"expires_in"`
 	AuthorizationDetails []AuthorizationDetail `json:"authorization_details,omitempty"`
 }
 

--- a/service/authorization/v2/rar_signer.go
+++ b/service/authorization/v2/rar_signer.go
@@ -1,0 +1,144 @@
+package authorization
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+// RARSigner mints RFC 9396 access tokens signed with an Ed25519 keypair.
+// The keypair is held in memory; rotating it invalidates every previously
+// issued token, which is the intended behaviour for a POC.
+type RARSigner struct {
+	mu         sync.RWMutex
+	privateKey ed25519.PrivateKey
+	jwkPrivate jwk.Key
+	jwkPublic  jwk.Key
+	jwks       jwk.Set
+	issuer     string
+	tokenTTL   time.Duration
+}
+
+// NewEphemeralRARSigner generates a fresh Ed25519 keypair. The kid is a UUID,
+// so each process gets a unique signing identity.
+func NewEphemeralRARSigner(issuer string, ttl time.Duration) (*RARSigner, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("rar: generate signing key: %w", err)
+	}
+	privJWK, err := jwk.FromRaw(priv)
+	if err != nil {
+		return nil, fmt.Errorf("rar: import private key: %w", err)
+	}
+	pubJWK, err := jwk.FromRaw(pub)
+	if err != nil {
+		return nil, fmt.Errorf("rar: import public key: %w", err)
+	}
+	kid := uuid.NewString()
+	for _, k := range []jwk.Key{privJWK, pubJWK} {
+		if err := k.Set(jwk.KeyIDKey, kid); err != nil {
+			return nil, fmt.Errorf("rar: set kid: %w", err)
+		}
+		if err := k.Set(jwk.AlgorithmKey, jwa.EdDSA); err != nil {
+			return nil, fmt.Errorf("rar: set alg: %w", err)
+		}
+		if err := k.Set(jwk.KeyUsageKey, "sig"); err != nil {
+			return nil, fmt.Errorf("rar: set use: %w", err)
+		}
+	}
+	set := jwk.NewSet()
+	if err := set.AddKey(pubJWK); err != nil {
+		return nil, fmt.Errorf("rar: register public key: %w", err)
+	}
+	return &RARSigner{
+		privateKey: priv,
+		jwkPrivate: privJWK,
+		jwkPublic:  pubJWK,
+		jwks:       set,
+		issuer:     issuer,
+		tokenTTL:   ttl,
+	}, nil
+}
+
+// Issue mints a signed JWT carrying the RFC 9396 authorization_details claim
+// plus the standard subject/audience/expiry framing.
+func (s *RARSigner) Issue(subject, audience string, details []AuthorizationDetail) (string, time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	now := time.Now()
+	exp := now.Add(s.tokenTTL)
+	tok := jwt.New()
+	if err := tok.Set(jwt.IssuerKey, s.issuer); err != nil {
+		return "", time.Time{}, err
+	}
+	if err := tok.Set(jwt.SubjectKey, subject); err != nil {
+		return "", time.Time{}, err
+	}
+	if audience != "" {
+		if err := tok.Set(jwt.AudienceKey, audience); err != nil {
+			return "", time.Time{}, err
+		}
+	}
+	if err := tok.Set(jwt.IssuedAtKey, now); err != nil {
+		return "", time.Time{}, err
+	}
+	if err := tok.Set(jwt.NotBeforeKey, now); err != nil {
+		return "", time.Time{}, err
+	}
+	if err := tok.Set(jwt.ExpirationKey, exp); err != nil {
+		return "", time.Time{}, err
+	}
+	if err := tok.Set(jwt.JwtIDKey, uuid.NewString()); err != nil {
+		return "", time.Time{}, err
+	}
+	if len(details) > 0 {
+		// Round-trip through JSON so the claim is plain map[string]any —
+		// jwx's serializer chokes on typed structs in custom claims.
+		payload, err := json.Marshal(details)
+		if err != nil {
+			return "", time.Time{}, fmt.Errorf("rar: marshal authorization_details: %w", err)
+		}
+		var generic []map[string]any
+		if err := json.Unmarshal(payload, &generic); err != nil {
+			return "", time.Time{}, fmt.Errorf("rar: re-decode authorization_details: %w", err)
+		}
+		if err := tok.Set("authorization_details", generic); err != nil {
+			return "", time.Time{}, err
+		}
+	}
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.EdDSA, s.jwkPrivate, jws.WithProtectedHeaders(s.protectedHeaders())))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("rar: sign: %w", err)
+	}
+	return string(signed), exp, nil
+}
+
+// JWKS returns the public JWK Set so resource servers can verify issued tokens.
+func (s *RARSigner) JWKS() jwk.Set {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.jwks
+}
+
+func (s *RARSigner) protectedHeaders() jws.Headers {
+	h := jws.NewHeaders()
+	if kid, ok := s.jwkPrivate.Get(jwk.KeyIDKey); ok {
+		_ = h.Set(jws.KeyIDKey, kid)
+	}
+	_ = h.Set(jws.TypeKey, "JWT")
+	return h
+}
+
+// ErrSignerNotConfigured is returned when the RAR endpoint is called but
+// signing has not been initialised (e.g. feature flag off).
+var ErrSignerNotConfigured = errors.New("rar: signer not configured")

--- a/service/authorization/v2/rar_test.go
+++ b/service/authorization/v2/rar_test.go
@@ -46,7 +46,8 @@ func TestRARSigner_RoundTripSignAndVerify(t *testing.T) {
 
 	// Resource server side: pull the public JWKS, parse the token against it.
 	set := signer.JWKS()
-	parsed, err := jwt.Parse([]byte(signed),
+	parsed, err := jwt.Parse(
+		[]byte(signed),
 		jwt.WithKeySet(set),
 		jwt.WithValidate(true),
 		jwt.WithIssuer("https://opentdf.local"),
@@ -177,7 +178,7 @@ type stubVerifier struct {
 
 func (s *stubVerifier) VerifyAccessToken(_ context.Context, tokenRaw string) (jwt.Token, error) {
 	if tokenRaw != s.expectedToken {
-		return nil, assertErr("unexpected subject token")
+		return nil, assertError("unexpected subject token")
 	}
 	t := jwt.New()
 	_ = t.Set(jwt.SubjectKey, s.subject)
@@ -185,9 +186,9 @@ func (s *stubVerifier) VerifyAccessToken(_ context.Context, tokenRaw string) (jw
 	return t, nil
 }
 
-type assertErr string
+type assertError string
 
-func (a assertErr) Error() string { return string(a) }
+func (a assertError) Error() string { return string(a) }
 
 // stubERS returns a fixed entity representation regardless of input — the test
 // owns the policy file, so it owns what selectors need to match.
@@ -300,7 +301,8 @@ func TestRAREndpoint_GrantsPermittedDetails(t *testing.T) {
 		}, got.Locations)
 
 	// Verify the issued JWT is valid under the published JWKS.
-	parsed, err := jwt.Parse([]byte(body.AccessToken),
+	parsed, err := jwt.Parse(
+		[]byte(body.AccessToken),
 		jwt.WithKeySet(endpoint.signer.JWKS()),
 		jwt.WithValidate(true),
 		jwt.WithIssuer("https://opentdf.local"),

--- a/service/authorization/v2/rar_test.go
+++ b/service/authorization/v2/rar_test.go
@@ -1,0 +1,425 @@
+package authorization
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/opentdf/platform/protocol/go/entity"
+	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	otdf "github.com/opentdf/platform/sdk"
+	"github.com/opentdf/platform/sdk/sdkconnect"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/policy/filestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// --- Signer ------------------------------------------------------------------
+
+func TestRARSigner_RoundTripSignAndVerify(t *testing.T) {
+	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
+
+	details := []AuthorizationDetail{
+		{
+			Type:      detailTypeOpenTDFAttribute,
+			Actions:   []string{"read"},
+			Locations: []string{"https://example.com/attr/classification/value/secret"},
+		},
+	}
+	signed, exp, err := signer.Issue("user-1", "kas.example", details)
+	require.NoError(t, err)
+	assert.True(t, exp.After(time.Now()))
+
+	// Resource server side: pull the public JWKS, parse the token against it.
+	set := signer.JWKS()
+	parsed, err := jwt.Parse([]byte(signed),
+		jwt.WithKeySet(set),
+		jwt.WithValidate(true),
+		jwt.WithIssuer("https://opentdf.local"),
+		jwt.WithAudience("kas.example"),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "user-1", parsed.Subject())
+	rawDetails, ok := parsed.Get("authorization_details")
+	require.True(t, ok)
+	rawJSON, err := json.Marshal(rawDetails)
+	require.NoError(t, err)
+	var roundTripped []AuthorizationDetail
+	require.NoError(t, json.Unmarshal(rawJSON, &roundTripped))
+	require.Len(t, roundTripped, 1)
+	assert.Equal(t, details[0].Type, roundTripped[0].Type)
+	assert.Equal(t, details[0].Actions, roundTripped[0].Actions)
+	assert.Equal(t, details[0].Locations, roundTripped[0].Locations)
+}
+
+func TestRARSigner_JWKSContainsPublicKeyOnly(t *testing.T) {
+	signer, err := NewEphemeralRARSigner("iss", time.Minute)
+	require.NoError(t, err)
+
+	set := signer.JWKS()
+	require.Equal(t, 1, set.Len())
+	pub, _ := set.Key(0)
+	// Symbol() / KeyType for OKP is "OKP"; signing key would be private.
+	assert.Equal(t, jwa.OKP, pub.KeyType())
+	// A public Ed25519 key must NOT serialize a "d" (private scalar) parameter.
+	buf, err := json.Marshal(pub)
+	require.NoError(t, err)
+	assert.NotContains(t, string(buf), `"d":`, "public JWK leaked private scalar")
+}
+
+// --- Parsing & validation ----------------------------------------------------
+
+func TestParseAuthorizationDetails(t *testing.T) {
+	t.Run("array", func(t *testing.T) {
+		raw := `[{"type":"opentdf_attribute","actions":["read"],"locations":["https://x/y/value/z"]}]`
+		got, err := parseAuthorizationDetails(raw)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "opentdf_attribute", got[0].Type)
+	})
+	t.Run("double-encoded", func(t *testing.T) {
+		inner := `[{"type":"opentdf_attribute","actions":["read"],"locations":["https://x/y/value/z"]}]`
+		raw, _ := json.Marshal(inner) // produces a JSON string literal
+		got, err := parseAuthorizationDetails(string(raw))
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+	})
+	t.Run("empty", func(t *testing.T) {
+		got, err := parseAuthorizationDetails("")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+	t.Run("garbage", func(t *testing.T) {
+		_, err := parseAuthorizationDetails("not json")
+		require.Error(t, err)
+	})
+}
+
+func TestValidateDetail(t *testing.T) {
+	good := AuthorizationDetail{
+		Type:      detailTypeOpenTDFAttribute,
+		Actions:   []string{"read"},
+		Locations: []string{"https://x"},
+	}
+	require.NoError(t, validateDetail(good))
+
+	cases := map[string]AuthorizationDetail{
+		"missing type":      {Actions: []string{"read"}, Locations: []string{"x"}},
+		"wrong type":        {Type: "other", Actions: []string{"read"}, Locations: []string{"x"}},
+		"missing actions":   {Type: detailTypeOpenTDFAttribute, Locations: []string{"x"}},
+		"missing locations": {Type: detailTypeOpenTDFAttribute, Actions: []string{"read"}},
+	}
+	for name, d := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, validateDetail(d))
+		})
+	}
+}
+
+// --- End-to-end via httptest -------------------------------------------------
+
+const integrationPolicy = `
+namespaces:
+  - name: example.com
+attributes:
+  - namespace: example.com
+    name: classification
+    rule: anyOf
+    values:
+      - value: secret
+      - value: public
+subject_mappings:
+  - attribute_value_fqn: https://example.com/attr/classification/value/secret
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .clearance
+                  operator: IN
+                  subject_external_values: [topsecret]
+    actions:
+      - name: read
+  - attribute_value_fqn: https://example.com/attr/classification/value/public
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .clearance
+                  operator: IN
+                  subject_external_values: [topsecret, none]
+    actions:
+      - name: read
+`
+
+// stubVerifier accepts a fixed subject token and returns a synthetic jwt.Token.
+// In production this would be the IdP-backed verifier from internal/auth.
+type stubVerifier struct {
+	expectedToken string
+	subject       string
+}
+
+func (s *stubVerifier) VerifyAccessToken(_ context.Context, tokenRaw string) (jwt.Token, error) {
+	if tokenRaw != s.expectedToken {
+		return nil, assertErr("unexpected subject token")
+	}
+	t := jwt.New()
+	_ = t.Set(jwt.SubjectKey, s.subject)
+	_ = t.Set(jwt.IssuerKey, "https://idp.example")
+	return t, nil
+}
+
+type assertErr string
+
+func (a assertErr) Error() string { return string(a) }
+
+// stubERS returns a fixed entity representation regardless of input — the test
+// owns the policy file, so it owns what selectors need to match.
+type stubERS struct {
+	props map[string]interface{}
+}
+
+func (s *stubERS) ResolveEntities(_ context.Context, req *entityresolutionV2.ResolveEntitiesRequest) (*entityresolutionV2.ResolveEntitiesResponse, error) {
+	st, err := structpb.NewStruct(s.props)
+	if err != nil {
+		return nil, err
+	}
+	reps := make([]*entityresolutionV2.EntityRepresentation, len(req.GetEntities()))
+	for i, e := range req.GetEntities() {
+		reps[i] = &entityresolutionV2.EntityRepresentation{
+			OriginalId:      e.GetEphemeralId(),
+			AdditionalProps: []*structpb.Struct{st},
+		}
+	}
+	return &entityresolutionV2.ResolveEntitiesResponse{EntityRepresentations: reps}, nil
+}
+
+func (s *stubERS) CreateEntityChainsFromTokens(_ context.Context, req *entityresolutionV2.CreateEntityChainsFromTokensRequest) (*entityresolutionV2.CreateEntityChainsFromTokensResponse, error) {
+	chains := make([]*entity.EntityChain, 0, len(req.GetTokens()))
+	for _, tok := range req.GetTokens() {
+		chains = append(chains, &entity.EntityChain{
+			EphemeralId: tok.GetEphemeralId(),
+			Entities: []*entity.Entity{
+				{
+					EphemeralId: "subject",
+					Category:    entity.Entity_CATEGORY_SUBJECT,
+					EntityType:  &entity.Entity_ClientId{ClientId: "rar-test-client"},
+				},
+			},
+		})
+	}
+	return &entityresolutionV2.CreateEntityChainsFromTokensResponse{EntityChains: chains}, nil
+}
+
+var _ sdkconnect.EntityResolutionServiceClientV2 = (*stubERS)(nil)
+
+func newTestEndpoint(t *testing.T, clearance string) (*RAREndpoint, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(integrationPolicy), 0o600))
+	store, err := filestore.NewStoreFromFile(path)
+	require.NoError(t, err)
+
+	svc := &Service{
+		sdk: &otdf.SDK{
+			EntityResolutionV2: &stubERS{props: map[string]interface{}{"clearance": clearance}},
+		},
+		logger: logger.CreateTestLogger(),
+		config: &Config{},
+		Tracer: noop.NewTracerProvider().Tracer(""),
+		cache:  store,
+	}
+	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
+
+	endpoint := &RAREndpoint{
+		pdp:      svc,
+		signer:   signer,
+		verifier: &stubVerifier{expectedToken: "subject-token", subject: "user-1"},
+	}
+	return endpoint, "subject-token"
+}
+
+func TestRAREndpoint_GrantsPermittedDetails(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	mux := http.NewServeMux()
+	endpoint.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("audience", "kas.example")
+	form.Set("authorization_details", `[
+        {
+            "type": "opentdf_attribute",
+            "actions": ["read"],
+            "locations": [
+                "https://example.com/attr/classification/value/secret",
+                "https://example.com/attr/classification/value/public"
+            ]
+        }
+    ]`)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body tokenExchangeResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "Bearer", body.TokenType)
+	assert.Equal(t, tokenTypeJWT, body.IssuedTokenType)
+	assert.Greater(t, body.ExpiresIn, int64(0))
+	require.Len(t, body.AuthorizationDetails, 1)
+	got := body.AuthorizationDetails[0]
+	assert.Equal(t, []string{"read"}, got.Actions)
+	assert.ElementsMatch(t,
+		[]string{
+			"https://example.com/attr/classification/value/secret",
+			"https://example.com/attr/classification/value/public",
+		}, got.Locations)
+
+	// Verify the issued JWT is valid under the published JWKS.
+	parsed, err := jwt.Parse([]byte(body.AccessToken),
+		jwt.WithKeySet(endpoint.signer.JWKS()),
+		jwt.WithValidate(true),
+		jwt.WithIssuer("https://opentdf.local"),
+		jwt.WithAudience("kas.example"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", parsed.Subject())
+}
+
+func TestRAREndpoint_FiltersOutDeniedLocations(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "none")
+	mux := http.NewServeMux()
+	endpoint.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("authorization_details", `[
+        {
+            "type": "opentdf_attribute",
+            "actions": ["read"],
+            "locations": [
+                "https://example.com/attr/classification/value/secret",
+                "https://example.com/attr/classification/value/public"
+            ]
+        }
+    ]`)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body tokenExchangeResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Len(t, body.AuthorizationDetails, 1)
+	got := body.AuthorizationDetails[0]
+	// "none" clearance: only the /public mapping matches.
+	assert.Equal(t, []string{"https://example.com/attr/classification/value/public"}, got.Locations)
+}
+
+func TestRAREndpoint_DeniesWhenNothingPermitted(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "")
+	mux := http.NewServeMux()
+	endpoint.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("authorization_details", `[
+        {
+            "type": "opentdf_attribute",
+            "actions": ["read"],
+            "locations": ["https://example.com/attr/classification/value/secret"]
+        }
+    ]`)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	var body rarErrorResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "access_denied", body.Error)
+}
+
+func TestRAREndpoint_RejectsBadSubjectToken(t *testing.T) {
+	endpoint, _ := newTestEndpoint(t, "topsecret")
+	mux := http.NewServeMux()
+	endpoint.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", "wrong-token")
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("authorization_details", `[{"type":"opentdf_attribute","actions":["read"],"locations":["x"]}]`)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestRAREndpoint_RejectsWrongGrantType(t *testing.T) {
+	endpoint, _ := newTestEndpoint(t, "topsecret")
+	mux := http.NewServeMux()
+	endpoint.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRAREndpoint_JWKSEndpoint(t *testing.T) {
+	endpoint, _ := newTestEndpoint(t, "topsecret")
+	mux := http.NewServeMux()
+	endpoint.Mount(mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + rarJWKSPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	set, err := jwk.ParseReader(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, 1, set.Len())
+}


### PR DESCRIPTION
## Summary

Adds a token-decoration endpoint that takes a verified upstream JWT and mints a new platform-signed access token carrying RFC 9396 `authorization_details`. The PDP fans the requested details out to the existing v2 decision path; only permitted (action × location) pairs end up in the issued token.

Built on top of `claude/remove-postgres-add-policy-qSz3v` so the file-backed PDP can serve every decision from memory — no Postgres in this flow.

### Flow

```
Client ── (1) OIDC ──▶ IdP
       ◀── ID Token ──

Client ── (2) POST /v2/authorization/token ──▶ opentdf authorization
                                                  │
                                                  │ verify subject_token
                                                  │ fan out to PDP per
                                                  │   authorization_detail
                                                  ▼
                                                PDP (file-backed)
                                                  │
                                                  ▼
                                                mint + sign JWT
       ◀── access_token (JWT with RAR claim) ──

Client ── (3) call KAS / others ─▶ resource server
       (verifies via GET /v2/authorization/jwks.json)
```

### Endpoints

| Method | Path | Notes |
|---|---|---|
| `POST` | `/v2/authorization/token` | RFC 8693 form-encoded request, RFC 9396 `authorization_details` |
| `GET` | `/v2/authorization/jwks.json` | Public JWK Set for verifying issued tokens |

### Request example

```http
POST /v2/authorization/token
Content-Type: application/x-www-form-urlencoded

grant_type=urn:ietf:params:oauth:grant-type:token-exchange
&subject_token=<IdP-issued JWT>
&subject_token_type=urn:ietf:params:oauth:token-type:id_token
&audience=kas.example
&authorization_details=[
  {"type":"opentdf_attribute",
   "actions":["read"],
   "locations":["https://example.com/attr/classification/value/secret"]}
]
```

Response (RFC 8693 §2.2):

```json
{
  "access_token": "eyJhbGciOiJFZERTQSI...",
  "issued_token_type": "urn:ietf:params:oauth:token-type:jwt",
  "token_type": "Bearer",
  "expires_in": 3600,
  "authorization_details": [
    {"type":"opentdf_attribute",
     "actions":["read"],
     "locations":["https://example.com/attr/classification/value/secret"]}
  ]
}
```

### Scope of the POC

Intentionally narrow — this is **token decoration**, not a full OAuth Authorization Server:

- Only `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`
- Only `requested_token_type=urn:ietf:params:oauth:token-type:jwt`
- Only detail `type="opentdf_attribute"` with `actions` + `locations`
- No `/authorize`, refresh tokens, PKCE, client registration, introspection, revocation
- Signing key is **ephemeral Ed25519** — process restart rotates it and invalidates outstanding tokens. KMS-backed signer is a follow-up.

### Configuration

```yaml
services:
  authorization:
    policy_file: ./policy.yaml      # from the file-store PR
    rar:
      enabled: true
      issuer: https://opentdf.local
      token_ttl: 1h
```

### Implementation

- `rar.go` — HTTP handlers (token + JWKS), parsing, validation, PDP fan-out. Sets up gRPC metadata + audit transaction on the request context so the PDP's existing audit + client-id machinery works when called outside an interceptor chain.
- `rar_signer.go` — Ed25519 keypair, JWT minting via jwx, JWKS export.
- `authorization.go` — single `buildRARHandler` helper returns the `HandlerServer` from every `RegisterFunc` exit; `serviceregistry` mounts routes on the platform HTTP mux.
- `config.go` — `RARConfig` (enabled, issuer, token_ttl) added under `services.authorization.rar`.

### Test plan

- [x] `rar_test.go` — signer round-trip + JWKS exposes public key only
- [x] Parser handles array, double-encoded string, empty, and garbage inputs
- [x] Validator rejects missing/wrong type, missing actions, missing locations
- [x] End-to-end via `httptest`: loads file-store policy, stubs ERS + verifier, posts to the live endpoint, parses the issued JWT under the JWKS, asserts granted `authorization_details` match what the PDP permits
- [x] Filters out denied locations (partial permit case)
- [x] Returns `403 access_denied` when nothing is permitted (RFC 9396 §6.1)
- [x] Rejects bad subject token (`401 invalid_token`)
- [x] Rejects wrong grant type (`400 unsupported_grant_type`)
- [x] JWKS endpoint serves a parseable JWK Set
- [x] `go vet ./...` clean
- [x] Full non-integration test suite green

### Follow-ups (not in this PR)

- Persistent signing key (KMS / file-backed) so tokens survive restart
- Additional detail types (registered resources, custom)
- DPoP / mTLS sender-constrained access tokens (RFC 9449)
- OAuth introspection endpoint
- Rate limiting / quota on token issuance

https://claude.ai/code/session_012rkAem93wo9rWDXCkPVcMd

---
_Generated by [Claude Code](https://claude.ai/code/session_012rkAem93wo9rWDXCkPVcMd)_