### PR TITLE
feat(authz): CWT subject + response tokens at /v2/authorization/token

### DIFF
--- a/opentdf-example.yaml
+++ b/opentdf-example.yaml
@@ -41,6 +41,22 @@ services:
   #   entitlement_policy_cache:
   #     enabled: false
   #     refresh_interval: 30s
+  #   rar:
+  #     enabled: false
+  #     issuer: opentdf-authorization
+  #     token_ttl: 1h
+  #     # CWT subject-token support (RFC 8392). Opt-in. When enabled the RAR
+  #     # endpoint accepts subject_token_type=urn:ietf:params:oauth:token-type:cwt
+  #     # and verifies COSE_Sign1 / ES256 signatures against the COSE Key Set
+  #     # published by the IdP that mints the CWTs (e.g. authnz-rs at
+  #     # /.well-known/cose-keys).
+  #     cwt_verifier:
+  #       enabled: false
+  #       cose_keys_url: https://authnz.example/.well-known/cose-keys
+  #       issuer: https://authnz.example
+  #       audience: opentdf-platform
+  #       algorithm: ES256
+  #       cache_ttl: 10m
 server:
   auth:
     enabled: true

--- a/service/authorization/v2/authorization.go
+++ b/service/authorization/v2/authorization.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentdf/platform/protocol/go/policy"
 	otdf "github.com/opentdf/platform/sdk"
 	"github.com/opentdf/platform/service/internal/access/v2"
+	authn "github.com/opentdf/platform/service/internal/auth"
 	"github.com/opentdf/platform/service/logger"
 	ctxAuth "github.com/opentdf/platform/service/pkg/auth"
 	"github.com/opentdf/platform/service/pkg/cache"
@@ -169,6 +170,39 @@ func buildRARHandler(svc *Service, cfg *Config, srp serviceregistry.Registration
 		signer:   signer,
 		verifier: srp.AccessTokenVerifier,
 	}
+
+	// Optional CWT subject-token verifier. Off by default; enabled when an
+	// operator configures rar.cwt_verifier.enabled=true. Failure to build
+	// the verifier disables CWT support but does NOT take the RAR endpoint
+	// down — JWT-family subject tokens continue to work.
+	if cfg.RAR.CWTVerifier.Enabled {
+		cacheTTL, err := time.ParseDuration(cfg.RAR.CWTVerifier.CacheTTL)
+		if err != nil {
+			srp.Logger.Error("invalid rar.cwt_verifier.cache_ttl, falling back to default",
+				slog.String("value", cfg.RAR.CWTVerifier.CacheTTL),
+				slog.Any("error", err))
+			cacheTTL = defaultCWTCacheTTL
+		}
+		cwtVerifier, err := authn.NewCWTVerifier(context.Background(), authn.CWTVerifierConfig{
+			COSEKeysURL: cfg.RAR.CWTVerifier.COSEKeysURL,
+			Issuer:      cfg.RAR.CWTVerifier.Issuer,
+			Audience:    cfg.RAR.CWTVerifier.Audience,
+			Algorithm:   cfg.RAR.CWTVerifier.Algorithm,
+			CacheTTL:    cacheTTL,
+		}, srp.Logger)
+		if err != nil {
+			srp.Logger.Error("failed to create CWT verifier; CWT subject tokens disabled",
+				slog.Any("error", err))
+		} else {
+			srp.Logger.Info("CWT subject-token verifier enabled",
+				slog.String("cose_keys_url", cfg.RAR.CWTVerifier.COSEKeysURL),
+				slog.String("issuer", cfg.RAR.CWTVerifier.Issuer),
+				slog.String("audience", cfg.RAR.CWTVerifier.Audience),
+			)
+			endpoint.cwtVerifier = cwtVerifier
+		}
+	}
+
 	return func(_ context.Context, mux *http.ServeMux) error {
 		endpoint.Mount(mux)
 		return nil

--- a/service/authorization/v2/authorization.go
+++ b/service/authorization/v2/authorization.go
@@ -159,16 +159,27 @@ func buildRARHandler(svc *Service, cfg *Config, srp serviceregistry.Registration
 		srp.Logger.Error("failed to create rar signer; rar endpoint will be disabled", slog.Any("error", err))
 		return nil
 	}
+	// Mint a parallel CWT signer alongside the JWT one. Failure here only
+	// disables the CWT response path; the JWT-explicit path keeps working.
+	cwtSigner, err := NewEphemeralRARCWTSigner(cfg.RAR.Issuer, ttl)
+	if err != nil {
+		srp.Logger.Error("failed to create rar CWT signer; CWT responses will be disabled",
+			slog.Any("error", err))
+		cwtSigner = nil
+	}
 	srp.Logger.Info("rar token endpoint enabled",
 		slog.String("issuer", cfg.RAR.Issuer),
 		slog.String("token_ttl", ttl.String()),
 		slog.String("token_path", rarTokenPath),
 		slog.String("jwks_path", rarJWKSPath),
+		slog.String("cose_keys_path", rarCOSEKeysPath),
+		slog.Bool("cwt_responses_enabled", cwtSigner != nil),
 	)
 	endpoint := &RAREndpoint{
-		pdp:      svc,
-		signer:   signer,
-		verifier: srp.AccessTokenVerifier,
+		pdp:       svc,
+		signer:    signer,
+		cwtSigner: cwtSigner,
+		verifier:  srp.AccessTokenVerifier,
 	}
 
 	// Optional CWT subject-token verifier. Off by default; enabled when an

--- a/service/authorization/v2/config.go
+++ b/service/authorization/v2/config.go
@@ -1,10 +1,20 @@
 package authorization
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 )
+
+// algorithmES256 is the only COSE signing algorithm the CWT verifier supports
+// today; authnz-rs and other CWT issuers in the OpenTDF ecosystem use ES256
+// (P-256 ECDSA).
+const algorithmES256 = "ES256"
+
+// defaultCWTCacheTTL is the fallback duration used when the operator-supplied
+// rar.cwt_verifier.cache_ttl is missing or unparseable.
+const defaultCWTCacheTTL = 10 * time.Minute
 
 // Manage config for EntitlementPolicyCache: attributes, subject mappings, and registered resources
 // Default: caching disabled, and if enabled, refresh interval defaulted to 30 seconds.
@@ -41,6 +51,30 @@ type RARConfig struct {
 	Enabled  bool   `mapstructure:"enabled" json:"enabled" default:"false"`
 	Issuer   string `mapstructure:"issuer" json:"issuer" default:"opentdf-authorization"`
 	TokenTTL string `mapstructure:"token_ttl" json:"token_ttl" default:"1h"`
+
+	// CWTVerifier opts the endpoint into accepting RFC 8392 CWT subject
+	// tokens (subject_token_type=urn:ietf:params:oauth:token-type:cwt) in
+	// addition to the JWT-family URNs the platform verifier already
+	// accepts. Disabled by default.
+	CWTVerifier CWTVerifierConfig `mapstructure:"cwt_verifier" json:"cwt_verifier"`
+}
+
+// CWTVerifierConfig configures the CWT subject-token verifier. When
+// `enabled`, the RAR endpoint will fetch the COSE Key Set from
+// `cose_keys_url` (a `/.well-known/cose-keys` endpoint published by the IdP
+// minting the CWTs), verify incoming COSE_Sign1 subject tokens with it,
+// and check the standard `iss` / `aud` / `exp` claims.
+type CWTVerifierConfig struct {
+	Enabled     bool   `mapstructure:"enabled" json:"enabled" default:"false"`
+	COSEKeysURL string `mapstructure:"cose_keys_url" json:"cose_keys_url"`
+	Issuer      string `mapstructure:"issuer" json:"issuer"`
+	Audience    string `mapstructure:"audience" json:"audience"`
+	// Algorithm is the COSE algorithm label of the IdP's signing key.
+	// Today only ES256 is supported (the algorithm authnz-rs uses).
+	Algorithm string `mapstructure:"algorithm" json:"algorithm" default:"ES256"`
+	// CacheTTL is how long the verifier caches the fetched COSE Key Set
+	// before refreshing. Tune to match the IdP's Cache-Control.
+	CacheTTL string `mapstructure:"cache_ttl" json:"cache_ttl" default:"10m"`
 }
 
 // Validate tests for a sensible configuration
@@ -66,6 +100,35 @@ func (c *Config) Validate() error {
 			)
 		}
 	}
+
+	return validateCWTVerifier(&c.RAR.CWTVerifier)
+}
+
+func validateCWTVerifier(c *CWTVerifierConfig) error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.COSEKeysURL == "" {
+		return errors.New("rar.cwt_verifier.enabled is true but cose_keys_url is empty")
+	}
+	if c.Issuer == "" {
+		return errors.New("rar.cwt_verifier.enabled is true but issuer is empty")
+	}
+	if c.Audience == "" {
+		return errors.New("rar.cwt_verifier.enabled is true but audience is empty")
+	}
+	if c.Algorithm == "" {
+		c.Algorithm = algorithmES256
+	}
+	if c.Algorithm != algorithmES256 {
+		return fmt.Errorf("rar.cwt_verifier.algorithm %q not supported (only ES256 today)", c.Algorithm)
+	}
+	if c.CacheTTL == "" {
+		c.CacheTTL = "10m"
+	}
+	if _, err := time.ParseDuration(c.CacheTTL); err != nil {
+		return fmt.Errorf("rar.cwt_verifier.cache_ttl invalid: %w", err)
+	}
 	return nil
 }
 
@@ -83,6 +146,16 @@ func (c *Config) LogValue() slog.Value {
 				slog.Bool("enabled", c.RAR.Enabled),
 				slog.String("issuer", c.RAR.Issuer),
 				slog.String("token_ttl", c.RAR.TokenTTL),
+				slog.Any("cwt_verifier",
+					slog.GroupValue(
+						slog.Bool("enabled", c.RAR.CWTVerifier.Enabled),
+						slog.String("cose_keys_url", c.RAR.CWTVerifier.COSEKeysURL),
+						slog.String("issuer", c.RAR.CWTVerifier.Issuer),
+						slog.String("audience", c.RAR.CWTVerifier.Audience),
+						slog.String("algorithm", c.RAR.CWTVerifier.Algorithm),
+						slog.String("cache_ttl", c.RAR.CWTVerifier.CacheTTL),
+					),
+				),
 			),
 		),
 		slog.Bool("allow_direct_entitlements", c.AllowDirectEntitlements),

--- a/service/authorization/v2/rar.go
+++ b/service/authorization/v2/rar.go
@@ -37,6 +37,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	authzV2 "github.com/opentdf/platform/protocol/go/authorization/v2"
 	"github.com/opentdf/platform/protocol/go/entity"
 	"github.com/opentdf/platform/protocol/go/policy"
@@ -55,6 +56,10 @@ const (
 	tokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"          //nolint:gosec // RFC 8693 IANA URI
 	tokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token" //nolint:gosec // RFC 8693 IANA URI
 	tokenTypeIDToken     = "urn:ietf:params:oauth:token-type:id_token"     //nolint:gosec // RFC 8693 IANA URI
+	// CWT (RFC 8392) subject tokens carry the base64url-encoded CBOR bytes
+	// of a COSE_Sign1 structure. Mirrors the IANA URN convention used for
+	// JWT-family subject token types.
+	tokenTypeCWT = "urn:ietf:params:oauth:token-type:cwt" //nolint:gosec // RFC 8392 / RFC 8693 token type URN
 
 	rarTokenPath = "/v2/authorization/token"
 	rarJWKSPath  = "/v2/authorization/jwks.json"
@@ -88,10 +93,18 @@ type rarErrorResponse struct {
 // RAREndpoint owns the dependencies for the token issuance flow. The PDP
 // dependency is the same Service that hosts GetEntitlements/GetDecision*, so
 // policy reuse is implicit — no second copy of the entitlement store.
+//
+// `verifier` validates JWT-family subject tokens (the OIDC id_token /
+// access_token URNs). `cwtVerifier`, when configured, validates CWT subject
+// tokens (urn:ietf:params:oauth:token-type:cwt) and is optional. If a CWT
+// subject token arrives without a configured CWT verifier the endpoint
+// reports unsupported subject_token_type, matching the behavior for any
+// other unrecognized URN.
 type RAREndpoint struct {
-	pdp      *Service
-	signer   *RARSigner
-	verifier authn.AccessTokenVerifier
+	pdp         *Service
+	signer      *RARSigner
+	verifier    authn.AccessTokenVerifier
+	cwtVerifier authn.CWTSubjectTokenVerifier
 }
 
 // Mount attaches the RAR token + JWKS handlers to the supplied mux.
@@ -136,6 +149,12 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 	switch subjectTokenType {
 	case tokenTypeIDToken, tokenTypeAccessToken:
 		// supported
+	case tokenTypeCWT:
+		if r.cwtVerifier == nil {
+			writeError(w, http.StatusBadRequest, "invalid_request",
+				"CWT subject tokens are not enabled on this server")
+			return
+		}
 	case "":
 		writeError(w, http.StatusBadRequest, "invalid_request", "subject_token_type is required")
 		return
@@ -155,12 +174,26 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 	}
 	audience := req.PostForm.Get("audience")
 
-	if r.verifier == nil {
-		writeError(w, http.StatusServiceUnavailable, "server_error",
-			"platform token verifier is not configured")
-		return
+	// Verify the subject token, dispatching by URN. JWT-family URNs use the
+	// platform's standard OIDC verifier; CWT uses the configured COSE_Sign1
+	// verifier and produces an unsigned-JWT representation of the verified
+	// claims so the downstream claims-mode ERS can parse them unchanged.
+	var (
+		verified    jwt.Token
+		tokenForERS = subjectToken
+		err         error
+	)
+	switch subjectTokenType {
+	case tokenTypeCWT:
+		verified, tokenForERS, err = r.cwtVerifier.VerifyCWTSubjectToken(ctx, subjectToken)
+	default:
+		if r.verifier == nil {
+			writeError(w, http.StatusServiceUnavailable, "server_error",
+				"platform token verifier is not configured")
+			return
+		}
+		verified, err = r.verifier.VerifyAccessToken(ctx, subjectToken)
 	}
-	verified, err := r.verifier.VerifyAccessToken(ctx, subjectToken)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "invalid_token",
 			"subject_token verification failed: "+err.Error())
@@ -195,7 +228,7 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	grants, err := r.materialize(ctx, subjectToken, filter)
+	grants, err := r.materialize(ctx, tokenForERS, filter)
 	if err != nil {
 		r.pdp.logger.ErrorContext(ctx, "rar PDP evaluation failed", slog.Any("error", err))
 		writeError(w, http.StatusInternalServerError, "server_error",

--- a/service/authorization/v2/rar.go
+++ b/service/authorization/v2/rar.go
@@ -61,8 +61,11 @@ const (
 	// JWT-family subject token types.
 	tokenTypeCWT = "urn:ietf:params:oauth:token-type:cwt" //nolint:gosec // RFC 8392 / RFC 8693 token type URN
 
-	rarTokenPath = "/v2/authorization/token"
-	rarJWKSPath  = "/v2/authorization/jwks.json"
+	rarTokenPath     = "/v2/authorization/token"
+	rarJWKSPath      = "/v2/authorization/jwks.json"
+	rarCOSEKeysPath  = "/v2/authorization/cose-keys"
+	contentTypeCWT   = "application/cwt+cbor"
+	contentTypeCOSEK = "application/cose-key-set+cbor"
 )
 
 // authzDetailRequest is a parsed authorization_details entry from the inbound
@@ -103,14 +106,36 @@ type rarErrorResponse struct {
 type RAREndpoint struct {
 	pdp         *Service
 	signer      *RARSigner
+	cwtSigner   *RARCWTSigner
 	verifier    authn.AccessTokenVerifier
 	cwtVerifier authn.CWTSubjectTokenVerifier
 }
 
-// Mount attaches the RAR token + JWKS handlers to the supplied mux.
+// Mount attaches the RAR token + JWKS + COSE Key Set handlers to the
+// supplied mux. The COSE Key Set is only published when a CWT signer is
+// configured; without it the route returns 503.
 func (r *RAREndpoint) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("POST "+rarTokenPath, r.handleToken)
 	mux.HandleFunc("GET "+rarJWKSPath, r.handleJWKS)
+	mux.HandleFunc("GET "+rarCOSEKeysPath, r.handleCOSEKeys)
+}
+
+func (r *RAREndpoint) handleCOSEKeys(w http.ResponseWriter, _ *http.Request) {
+	if r.cwtSigner == nil {
+		writeError(w, http.StatusServiceUnavailable, "server_error",
+			"CWT signer not configured")
+		return
+	}
+	set, err := r.cwtSigner.COSEKeySet()
+	if err != nil {
+		r.pdp.logger.Error("failed to encode COSE Key Set", slog.Any("error", err))
+		writeError(w, http.StatusInternalServerError, "server_error",
+			"could not encode COSE Key Set")
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeCOSEK)
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write(set)
 }
 
 func (r *RAREndpoint) handleJWKS(w http.ResponseWriter, _ *http.Request) {
@@ -163,13 +188,27 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 			"unsupported subject_token_type "+subjectTokenType)
 		return
 	}
+	// requested_token_type controls the response format. Default is CWT —
+	// the platform issues authorization_details inside an RFC 8392 CWT
+	// (COSE_Sign1 / ES256) and the response body is raw CBOR with content
+	// type application/cwt+cbor. Clients can opt back into the legacy JSON
+	// envelope by setting requested_token_type to the JWT URN.
 	requestedTokenType := req.PostForm.Get("requested_token_type")
 	if requestedTokenType == "" {
-		requestedTokenType = tokenTypeJWT
+		requestedTokenType = tokenTypeCWT
 	}
-	if requestedTokenType != tokenTypeJWT {
+	switch requestedTokenType {
+	case tokenTypeCWT:
+		if r.cwtSigner == nil {
+			writeError(w, http.StatusBadRequest, "invalid_request",
+				"CWT response tokens are not enabled on this server")
+			return
+		}
+	case tokenTypeJWT:
+		// JSON envelope path; r.signer is required (validated at startup).
+	default:
 		writeError(w, http.StatusBadRequest, "invalid_request",
-			"only "+tokenTypeJWT+" is supported as requested_token_type")
+			"unsupported requested_token_type "+requestedTokenType)
 		return
 	}
 	audience := req.PostForm.Get("audience")
@@ -246,24 +285,39 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	signed, exp, err := r.signer.Issue(subjectStr, audience, grants)
-	if err != nil {
-		r.pdp.logger.ErrorContext(ctx, "rar token sign failed", slog.Any("error", err))
-		writeError(w, http.StatusInternalServerError, "server_error", "could not mint access token")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	if err := json.NewEncoder(w).Encode(tokenExchangeResponse{
-		AccessToken:          signed,
-		IssuedTokenType:      tokenTypeJWT,
-		TokenType:            "Bearer",
-		ExpiresIn:            int64(time.Until(exp).Seconds()),
-		AuthorizationDetails: grants,
-	}); err != nil {
-		r.pdp.logger.Error("failed to encode rar response", slog.Any("error", err))
+	switch requestedTokenType {
+	case tokenTypeCWT:
+		raw, _, err := r.cwtSigner.Issue(subjectStr, audience, grants)
+		if err != nil {
+			r.pdp.logger.ErrorContext(ctx, "rar cwt sign failed", slog.Any("error", err))
+			writeError(w, http.StatusInternalServerError, "server_error", "could not mint CWT access token")
+			return
+		}
+		// Raw CBOR body; access_token claims (sub, aud, exp, authorization_details)
+		// live inside the CWT itself, so no JSON envelope is needed.
+		w.Header().Set("Content-Type", contentTypeCWT)
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		_, _ = w.Write(raw)
+	default: // tokenTypeJWT
+		signed, exp, err := r.signer.Issue(subjectStr, audience, grants)
+		if err != nil {
+			r.pdp.logger.ErrorContext(ctx, "rar token sign failed", slog.Any("error", err))
+			writeError(w, http.StatusInternalServerError, "server_error", "could not mint access token")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		if err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+			AccessToken:          signed,
+			IssuedTokenType:      tokenTypeJWT,
+			TokenType:            "Bearer",
+			ExpiresIn:            int64(time.Until(exp).Seconds()),
+			AuthorizationDetails: grants,
+		}); err != nil {
+			r.pdp.logger.Error("failed to encode rar response", slog.Any("error", err))
+		}
 	}
 }
 

--- a/service/authorization/v2/rar_cwt_response_test.go
+++ b/service/authorization/v2/rar_cwt_response_test.go
@@ -1,0 +1,213 @@
+package authorization
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/opentdf/platform/service/access/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/go-cose"
+)
+
+// --- helpers ----------------------------------------------------------------
+
+// stripCWTTag drops the optional RFC 8392 §6 CWT tag prefix (0xd8, 0x3d)
+// so go-cose can parse the bare COSE_Sign1.
+func stripCWTTag(b []byte) []byte {
+	if len(b) >= 2 && b[0] == 0xd8 && b[1] == 0x3d {
+		return b[2:]
+	}
+	return b
+}
+
+// fetchCOSEKeySet pulls and parses the platform's published COSE Key Set
+// the same way an external PEP would.
+func fetchCOSEKeySet(t *testing.T, baseURL string) []*ecdsa.PublicKey {
+	t.Helper()
+	resp, err := http.Get(baseURL + rarCOSEKeysPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, contentTypeCOSEK, resp.Header.Get("Content-Type"))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var keys []map[int64]any
+	require.NoError(t, cbor.Unmarshal(body, &keys))
+	require.NotEmpty(t, keys)
+
+	out := make([]*ecdsa.PublicKey, 0, len(keys))
+	for _, k := range keys {
+		x, _ := k[coseXLabel].([]byte)
+		y, _ := k[coseYLabel].([]byte)
+		require.NotEmpty(t, x)
+		require.NotEmpty(t, y)
+		out = append(out, ecKeyFromXY(x, y))
+	}
+	return out
+}
+
+func ecKeyFromXY(x, y []byte) *ecdsa.PublicKey {
+	key := &ecdsa.PublicKey{Curve: elliptic.P256()}
+	key.X = new(big.Int).SetBytes(x)
+	key.Y = new(big.Int).SetBytes(y)
+	return key
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestRAREndpoint_CWTResponse_IsDefault(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	// Build a form with NO requested_token_type — the new default is CWT.
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("audience", "kas.example")
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, contentTypeCWT, resp.Header.Get("Content-Type"))
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// Verify the response is a real, signed COSE_Sign1 we can decode.
+	cose1 := stripCWTTag(raw)
+	var msg cose.Sign1Message
+	require.NoError(t, msg.UnmarshalCBOR(cose1))
+
+	// Decode the payload as a CBOR map and assert the standard claims plus
+	// authorization_details are present.
+	var claims map[any]any
+	require.NoError(t, cbor.Unmarshal(msg.Payload, &claims))
+	assert.Equal(t, "https://opentdf.local", claims[uint64(cwtClaimIss)])
+	assert.Equal(t, "user-1", claims[uint64(cwtClaimSub)])
+	assert.Equal(t, "kas.example", claims[uint64(cwtClaimAud)])
+	details, ok := claims[local.AuthorizationDetailsClaim].([]any)
+	require.True(t, ok, "expected authorization_details array, got %T", claims[local.AuthorizationDetailsClaim])
+	require.NotEmpty(t, details)
+}
+
+func TestRAREndpoint_CWTResponse_VerifiesAgainstPublishedCOSEKeySet(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+
+	var msg cose.Sign1Message
+	require.NoError(t, msg.UnmarshalCBOR(stripCWTTag(body)))
+
+	// Pull keys from the platform's published COSE Key Set and verify the
+	// response signature with one of them — proves the same key pair signs
+	// the token and answers the COSE key endpoint.
+	pubKeys := fetchCOSEKeySet(t, srv.URL)
+	require.NotEmpty(t, pubKeys)
+
+	verified := false
+	for _, k := range pubKeys {
+		v, err := cose.NewVerifier(cose.AlgorithmES256, k)
+		require.NoError(t, err)
+		if err := msg.Verify(nil, v); err == nil {
+			verified = true
+			break
+		}
+	}
+	assert.True(t, verified, "no published COSE key verified the response signature")
+}
+
+func TestRAREndpoint_CWTResponse_DisabledWhenSignerMissing(t *testing.T) {
+	// Build an endpoint with a JWT signer but no CWT signer — CWT response
+	// must fall through to 400.
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+	endpoint.cwtSigner = nil // simulate "CWT signer failed at startup"
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRAREndpoint_COSEKeysEndpoint(t *testing.T) {
+	endpoint, _ := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + rarCOSEKeysPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, contentTypeCOSEK, resp.Header.Get("Content-Type"))
+}
+
+func TestRAREndpoint_JWTResponse_OptIn(t *testing.T) {
+	// Clients explicitly asking for JWT keep getting the JSON envelope.
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeJWT)
+
+	body := doTokenRequest(t, srv.URL, form)
+	require.NotEmpty(t, body.AccessToken)
+	require.Equal(t, "Bearer", body.TokenType)
+	require.Equal(t, tokenTypeJWT, body.IssuedTokenType)
+}
+
+func TestRAREndpoint_UnknownRequestedTokenTypeRejected(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", "urn:bogus:token-type")
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/service/authorization/v2/rar_cwt_signer.go
+++ b/service/authorization/v2/rar_cwt_signer.go
@@ -1,0 +1,218 @@
+// Package authorization — RAR CWT signer.
+//
+// Mints RFC 8392 CWTs (COSE_Sign1 / ES256) carrying the materialized RFC 9396
+// authorization_details payload. Mirrors RARSigner but emits CBOR instead of
+// JWT/JWS so consumers that prefer CWT throughout (e.g. an authnz-rs-issued
+// CWT subject token round-tripping back as a CWT access token) don't have to
+// straddle two encodings.
+//
+// Wire shape:
+//
+//	CWT payload (CBOR map):
+//	  1 (iss):  configured issuer
+//	  2 (sub):  entity subject string
+//	  3 (aud):  caller-supplied audience (omitted if empty)
+//	  4 (exp):  unix seconds
+//	  5 (nbf):  unix seconds
+//	  6 (iat):  unix seconds
+//	  7 (cti):  16-byte UUID
+//	  "authorization_details": [ {type, actions[], locations[], obligations[]}, ... ]
+//
+// Signing key is an ephemeral ES256 (P-256) keypair generated at construction.
+// The public half is published via COSEKeySet() — the COSE Key Set CBOR shape
+// authnz-rs already serves at /.well-known/cose-keys, so PEPs can use one
+// verifier code path for both the subject-side and access-side tokens.
+package authorization
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/google/uuid"
+	"github.com/veraison/go-cose"
+
+	"github.com/opentdf/platform/service/access/local"
+)
+
+// COSE Key Set labels (RFC 9052 §7) used when building the published key.
+const (
+	coseKtyLabel = 1
+	coseKidLabel = 2
+	coseAlgLabel = 3
+	coseCrvLabel = -1
+	coseXLabel   = -2
+	coseYLabel   = -3
+	coseKtyEC2   = 2
+	coseAlgES256 = -7
+	coseCrvP256  = 1
+)
+
+// CWT integer claim labels (RFC 8392 §4).
+const (
+	cwtClaimIss = 1
+	cwtClaimSub = 2
+	cwtClaimAud = 3
+	cwtClaimExp = 4
+	cwtClaimNbf = 5
+	cwtClaimIat = 6
+	cwtClaimCti = 7
+)
+
+// p256CoordLen is the byte length of an X9.62 P-256 coordinate.
+const p256CoordLen = 32
+
+// ErrCWTSignerNotConfigured is returned when the RAR endpoint is asked for a
+// CWT response token but the CWT signer was never built.
+var ErrCWTSignerNotConfigured = errors.New("rar: CWT signer not configured")
+
+// RARCWTSigner mints RFC 8392 CWTs over an ephemeral ES256 keypair. The
+// matching public key is published via COSEKeySet().
+type RARCWTSigner struct {
+	mu     sync.RWMutex
+	priv   *ecdsa.PrivateKey
+	kid    []byte
+	issuer string
+	ttl    time.Duration
+}
+
+// NewEphemeralRARCWTSigner generates a fresh ES256 (P-256) keypair and
+// returns a ready-to-use signer. The kid is a UUID, so each process gets a
+// unique signing identity (matching RARSigner's behavior).
+func NewEphemeralRARCWTSigner(issuer string, ttl time.Duration) (*RARCWTSigner, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("rar cwt: generate signing key: %w", err)
+	}
+	kid, err := uuid.New().MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("rar cwt: marshal kid: %w", err)
+	}
+	return &RARCWTSigner{
+		priv:   priv,
+		kid:    kid,
+		issuer: issuer,
+		ttl:    ttl,
+	}, nil
+}
+
+// Issue mints a CWT carrying the supplied authorization_details grant set.
+// Returns the raw CBOR bytes of the (tagged) COSE_Sign1 plus the absolute
+// expiry time so callers can populate response framing if needed.
+func (s *RARCWTSigner) Issue(subject, audience string, grants []local.Grant) ([]byte, time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now()
+	exp := now.Add(s.ttl)
+	cti, err := uuid.New().MarshalBinary()
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: cti: %w", err)
+	}
+
+	claims := map[any]any{
+		cwtClaimIss: s.issuer,
+		cwtClaimSub: subject,
+		cwtClaimExp: exp.Unix(),
+		cwtClaimNbf: now.Unix(),
+		cwtClaimIat: now.Unix(),
+		cwtClaimCti: cti,
+	}
+	if audience != "" {
+		claims[cwtClaimAud] = audience
+	}
+	if len(grants) > 0 {
+		// authorization_details lives at a text label, matching the JSON
+		// claim name. Each grant becomes a CBOR map with string keys so a
+		// CBOR-aware PEP gets the same shape it would from JSON.
+		claims[local.AuthorizationDetailsClaim] = grantsToCBOR(grants)
+	}
+
+	payload, err := cbor.Marshal(claims)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: encode claims: %w", err)
+	}
+
+	signer, err := cose.NewSigner(cose.AlgorithmES256, s.priv)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: new signer: %w", err)
+	}
+	msg := cose.Sign1Message{
+		Headers: cose.Headers{
+			Protected: cose.ProtectedHeader{
+				cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
+				cose.HeaderLabelKeyID:     s.kid,
+			},
+		},
+		Payload: payload,
+	}
+	if err := msg.Sign(rand.Reader, nil, signer); err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: sign: %w", err)
+	}
+	raw, err := msg.MarshalCBOR()
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: marshal: %w", err)
+	}
+	// Wrap in CWT tag #61 per RFC 8392 §6 so naive consumers can detect the
+	// payload type without inspecting the structure.
+	tagged := append([]byte{0xd8, 0x3d}, raw...)
+	return tagged, exp, nil
+}
+
+// COSEKeySet returns the CBOR-encoded one-entry COSE Key Set (RFC 9052 §7)
+// containing this signer's public key, suitable for serving at the
+// /v2/authorization/cose-keys endpoint.
+func (s *RARCWTSigner) COSEKeySet() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	x := padCoord(s.priv.X.Bytes())
+	y := padCoord(s.priv.Y.Bytes())
+	key := map[int64]any{
+		coseKtyLabel: int64(coseKtyEC2),
+		coseAlgLabel: int64(coseAlgES256),
+		coseCrvLabel: int64(coseCrvP256),
+		coseXLabel:   x,
+		coseYLabel:   y,
+		coseKidLabel: s.kid,
+	}
+	buf, err := cbor.Marshal([]map[int64]any{key})
+	if err != nil {
+		return nil, fmt.Errorf("rar cwt: marshal cose key set: %w", err)
+	}
+	return buf, nil
+}
+
+// grantsToCBOR converts a Grant slice to a CBOR array-of-maps with string
+// keys so the wire shape mirrors the JSON shape exactly.
+func grantsToCBOR(grants []local.Grant) []map[string]any {
+	out := make([]map[string]any, 0, len(grants))
+	for _, g := range grants {
+		m := map[string]any{
+			"type":      g.Type,
+			"actions":   g.Actions,
+			"locations": g.Locations,
+		}
+		if len(g.Obligations) > 0 {
+			m["obligations"] = g.Obligations
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// padCoord left-pads an X9.62 EC coordinate to the fixed P-256 length so
+// COSE consumers don't have to handle short-form integers.
+func padCoord(b []byte) []byte {
+	if len(b) >= p256CoordLen {
+		return b[len(b)-p256CoordLen:]
+	}
+	out := make([]byte, p256CoordLen)
+	copy(out[p256CoordLen-len(b):], b)
+	return out
+}

--- a/service/authorization/v2/rar_cwt_test.go
+++ b/service/authorization/v2/rar_cwt_test.go
@@ -1,0 +1,302 @@
+package authorization
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/opentdf/platform/protocol/go/entity"
+	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	otdf "github.com/opentdf/platform/sdk"
+	authn "github.com/opentdf/platform/service/internal/auth"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/policy/filestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/go-cose"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// --- CWT subject-token test fixtures ----------------------------------------
+
+// padBytes left-pads byte slices to a fixed length so the CBOR
+// representation of an ECDSA coordinate is always 32 bytes for P-256.
+func padBytes(b []byte, n int) []byte {
+	if len(b) >= n {
+		return b[len(b)-n:]
+	}
+	out := make([]byte, n)
+	copy(out[n-len(b):], b)
+	return out
+}
+
+// coseKeySetCBOR is a one-entry COSE Key Set (RFC 9052 §7) carrying the
+// supplied P-256 public key with kid.
+func coseKeySetCBOR(t *testing.T, pub *ecdsa.PublicKey, kid []byte) []byte {
+	t.Helper()
+	key := map[int64]any{
+		1:  int64(2),  // kty = EC2
+		3:  int64(-7), // alg = ES256
+		-1: int64(1),  // crv = P-256
+		-2: padBytes(pub.X.Bytes(), 32),
+		-3: padBytes(pub.Y.Bytes(), 32),
+		2:  kid,
+	}
+	buf, err := cbor.Marshal([]map[int64]any{key})
+	require.NoError(t, err)
+	return buf
+}
+
+// signCWT returns a base64url-encoded COSE_Sign1 CWT with the supplied
+// standard and custom claims, mirroring the shape of an authnz-rs token.
+func signCWT(t *testing.T, priv *ecdsa.PrivateKey, kid []byte, claims map[any]any) string {
+	t.Helper()
+	payload, err := cbor.Marshal(claims)
+	require.NoError(t, err)
+	signer, err := cose.NewSigner(cose.AlgorithmES256, priv)
+	require.NoError(t, err)
+	msg := cose.Sign1Message{
+		Headers: cose.Headers{
+			Protected: cose.ProtectedHeader{
+				cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
+				cose.HeaderLabelKeyID:     kid,
+			},
+		},
+		Payload: payload,
+	}
+	require.NoError(t, msg.Sign(rand.Reader, nil, signer))
+	raw, err := msg.MarshalCBOR()
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// cwtClaims builds a CWT claims map (CBOR integer labels for standard claims,
+// text labels for custom ones, matching the authnz-rs encoding).
+func cwtClaims(iss, aud, sub string, ttl time.Duration, custom map[string]any) map[any]any {
+	now := time.Now().Unix()
+	out := map[any]any{
+		int64(1): iss,
+		int64(2): sub,
+		int64(3): aud,
+		int64(4): now + int64(ttl.Seconds()),
+		int64(6): now,
+	}
+	for k, v := range custom {
+		out[k] = v
+	}
+	return out
+}
+
+// keySetServer mimics authnz-rs's /.well-known/cose-keys endpoint.
+func keySetServer(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/cose-key-set+cbor")
+		_, _ = w.Write(body)
+	}))
+}
+
+// cwtERSTokenAware behaves like the existing stubERS but reads claims out of
+// the (unsigned) JWT the CWT verifier produced, so the integration test
+// confirms the synthetic-JWT bridge actually flows through.
+type cwtERSTokenAware struct{}
+
+func (cwtERSTokenAware) ResolveEntities(_ context.Context, req *entityresolutionV2.ResolveEntitiesRequest) (*entityresolutionV2.ResolveEntitiesResponse, error) {
+	// Each entity carries a Claims any that the upstream chain put on it.
+	reps := make([]*entityresolutionV2.EntityRepresentation, len(req.GetEntities()))
+	for i, e := range req.GetEntities() {
+		st, _ := structpb.NewStruct(map[string]any{
+			"clearance":    "topsecret",
+			"arkavo_roles": []any{"admin"},
+		})
+		reps[i] = &entityresolutionV2.EntityRepresentation{
+			OriginalId:      e.GetEphemeralId(),
+			AdditionalProps: []*structpb.Struct{st},
+		}
+	}
+	return &entityresolutionV2.ResolveEntitiesResponse{EntityRepresentations: reps}, nil
+}
+
+func (cwtERSTokenAware) CreateEntityChainsFromTokens(_ context.Context, req *entityresolutionV2.CreateEntityChainsFromTokensRequest) (*entityresolutionV2.CreateEntityChainsFromTokensResponse, error) {
+	chains := make([]*entity.EntityChain, 0, len(req.GetTokens()))
+	for _, tok := range req.GetTokens() {
+		// Decoding the JWT itself is the integration-side ERS's concern.
+		// For this test, just acknowledge the chain by EphemeralId.
+		chains = append(chains, &entity.EntityChain{
+			EphemeralId: tok.GetEphemeralId(),
+			Entities: []*entity.Entity{{
+				EphemeralId: "subject",
+				Category:    entity.Entity_CATEGORY_SUBJECT,
+				EntityType:  &entity.Entity_ClientId{ClientId: "rar-cwt-test"},
+			}},
+		})
+	}
+	return &entityresolutionV2.CreateEntityChainsFromTokensResponse{EntityChains: chains}, nil
+}
+
+// newCWTTestEndpoint wires a RAREndpoint with both the OIDC verifier
+// (stubbed off — not used in these tests) and a real CWT verifier pointed
+// at a local key-set server.
+func newCWTTestEndpoint(t *testing.T, priv *ecdsa.PrivateKey, kid []byte) (*RAREndpoint, *httptest.Server) {
+	t.Helper()
+	keySrv := keySetServer(t, coseKeySetCBOR(t, &priv.PublicKey, kid))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(integrationPolicy), 0o600))
+	store, err := filestore.NewStoreFromFile(path)
+	require.NoError(t, err)
+
+	svc := &Service{
+		sdk: &otdf.SDK{
+			EntityResolutionV2: cwtERSTokenAware{},
+		},
+		logger: logger.CreateTestLogger(),
+		config: &Config{},
+		Tracer: noop.NewTracerProvider().Tracer(""),
+		cache:  store,
+	}
+	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
+
+	cwtVerifier, err := authn.NewCWTVerifier(context.Background(), authn.CWTVerifierConfig{
+		COSEKeysURL: keySrv.URL,
+		Issuer:      "https://authnz.example",
+		Audience:    "opentdf-platform",
+		Algorithm:   "ES256",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+
+	endpoint := &RAREndpoint{
+		pdp:         svc,
+		signer:      signer,
+		cwtVerifier: cwtVerifier,
+	}
+	return endpoint, keySrv
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestRAREndpoint_CWT_HappyPath(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	kid := []byte("test-kid-1")
+
+	endpoint, keySrv := newCWTTestEndpoint(t, priv, kid)
+	defer keySrv.Close()
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	subjectToken := signCWT(t, priv, kid, cwtClaims(
+		"https://authnz.example",
+		"opentdf-platform",
+		"user-1",
+		time.Hour,
+		map[string]any{
+			"email":             "alice@example.com",
+			"arkavo_roles":      []any{"admin"},
+			"arkavo_account_id": "acct-1",
+		},
+	))
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("audience", "kas.example")
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body tokenExchangeResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.NotEmpty(t, body.AccessToken)
+	assert.NotEmpty(t, body.AuthorizationDetails)
+}
+
+func TestRAREndpoint_CWT_RejectsBadSignature(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	other, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	kid := []byte("test-kid-2")
+
+	endpoint, keySrv := newCWTTestEndpoint(t, priv, kid)
+	defer keySrv.Close()
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	// Sign with the wrong key; the published COSE Key Set has the other key.
+	subjectToken := signCWT(t, other, kid, cwtClaims(
+		"https://authnz.example", "opentdf-platform", "user-1", time.Hour, nil))
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestRAREndpoint_CWT_DisabledWhenVerifierNotConfigured(t *testing.T) {
+	// Reuse the standard JWT-only test endpoint — no cwtVerifier wired.
+	endpoint, _ := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", "any-token")
+	form.Set("subject_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	var body rarErrorResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Contains(t, body.ErrorDescription, "CWT subject tokens are not enabled")
+}
+
+func TestRAREndpoint_CWT_RejectsMalformedBase64(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	kid := []byte("test-kid-3")
+	endpoint, keySrv := newCWTTestEndpoint(t, priv, kid)
+	defer keySrv.Close()
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", "!!!not base64!!!")
+	form.Set("subject_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}

--- a/service/authorization/v2/rar_cwt_test.go
+++ b/service/authorization/v2/rar_cwt_test.go
@@ -171,6 +171,8 @@ func newCWTTestEndpoint(t *testing.T, priv *ecdsa.PrivateKey, kid []byte) (*RARE
 	}
 	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
 	require.NoError(t, err)
+	cwtSigner, err := NewEphemeralRARCWTSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
 
 	cwtVerifier, err := authn.NewCWTVerifier(context.Background(), authn.CWTVerifierConfig{
 		COSEKeysURL: keySrv.URL,
@@ -184,6 +186,7 @@ func newCWTTestEndpoint(t *testing.T, priv *ecdsa.PrivateKey, kid []byte) (*RARE
 	endpoint := &RAREndpoint{
 		pdp:         svc,
 		signer:      signer,
+		cwtSigner:   cwtSigner,
 		cwtVerifier: cwtVerifier,
 	}
 	return endpoint, keySrv
@@ -217,6 +220,7 @@ func TestRAREndpoint_CWT_HappyPath(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 	form.Set("audience", "kas.example")
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
@@ -251,6 +255,7 @@ func TestRAREndpoint_CWT_RejectsBadSignature(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
 		strings.NewReader(form.Encode()))
@@ -269,6 +274,7 @@ func TestRAREndpoint_CWT_DisabledWhenVerifierNotConfigured(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", "any-token")
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
 		strings.NewReader(form.Encode()))
@@ -293,6 +299,7 @@ func TestRAREndpoint_CWT_RejectsMalformedBase64(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", "!!!not base64!!!")
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
 		strings.NewReader(form.Encode()))

--- a/service/authorization/v2/rar_test.go
+++ b/service/authorization/v2/rar_test.go
@@ -243,11 +243,14 @@ func newTestEndpoint(t *testing.T, clearance string) (*RAREndpoint, string) {
 	}
 	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
 	require.NoError(t, err)
+	cwtSigner, err := NewEphemeralRARCWTSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
 
 	endpoint := &RAREndpoint{
-		pdp:      svc,
-		signer:   signer,
-		verifier: &stubVerifier{expectedToken: "subject-token", subject: "user-1"},
+		pdp:       svc,
+		signer:    signer,
+		cwtSigner: cwtSigner,
+		verifier:  &stubVerifier{expectedToken: "subject-token", subject: "user-1"},
 	}
 	return endpoint, "subject-token"
 }
@@ -263,6 +266,7 @@ func TestRAREndpoint_MaterializesFullEntitlementsByDefault(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeJWT)
 	form.Set("audience", "kas.example")
 	// Note: no authorization_details — we expect EVERYTHING.
 
@@ -399,6 +403,7 @@ func TestRAREndpoint_RejectsBadSubjectToken(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", "wrong-token")
 	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	require.NoError(t, err)
@@ -446,6 +451,11 @@ func baseForm(subjectToken string) url.Values {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeIDToken)
+	// Existing tests in this file assert on the JSON envelope shape. The
+	// platform default is now CWT (raw CBOR body); opt back into JWT here
+	// so each helper test stays focused on its specific concern instead of
+	// re-asserting the format choice.
+	form.Set("requested_token_type", tokenTypeJWT)
 	return form
 }
 

--- a/service/go.mod
+++ b/service/go.mod
@@ -58,9 +58,12 @@ require (
 
 require (
 	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/moby/moby/api v1.54.1 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/veraison/go-cose v1.3.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 )
 
 require (

--- a/service/go.sum
+++ b/service/go.sum
@@ -111,6 +111,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
+github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/go-asn1-ber/asn1-ber v1.5.8-0.20250403174932-29230038a667 h1:BP4M0CvQ4S3TGls2FvczZtj5Re/2ZzkV9VwqPHH/3Bo=
@@ -357,6 +359,10 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/vektah/gqlparser/v2 v2.5.26 h1:REqqFkO8+SOEgZHR/eHScjjVjGS8Nk3RMO/juiTobN4=
 github.com/vektah/gqlparser/v2 v2.5.26/go.mod h1:D1/VCZtV3LPnQrcPBeR/q5jkSQIPti0uYCP/RI0gIeo=
+github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7rk=
+github.com/veraison/go-cose v1.3.0/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/service/internal/auth/cwt_verifier.go
+++ b/service/internal/auth/cwt_verifier.go
@@ -1,0 +1,533 @@
+// Package auth — CWT subject-token verifier for the RFC 8693 token-exchange
+// endpoint at /v2/authorization/token.
+//
+// The verifier accepts base64url-encoded RFC 8392 CWTs (COSE_Sign1 over CBOR,
+// ES256 today) issued by an IdP that publishes its signing keys at a
+// /.well-known/cose-keys endpoint (RFC 9052 COSE Key Set in CBOR). It
+// verifies the signature, validates the standard claims (iss / aud / exp /
+// nbf), and returns:
+//
+//  1. A `jwt.Token` populated from the verified CWT claims, used by the RAR
+//     endpoint for subject and audit-context extraction. CWT integer label
+//     claims (1=iss, 2=sub, 3=aud, 4=exp, 5=nbf, 6=iat, 7=cti) are mapped to
+//     their JWT-equivalent string keys; arkavo-rs text-label custom claims
+//     are passed through unchanged.
+//
+//  2. An *unsigned* JWT serialization (`alg=none`) of the same claims. The
+//     downstream claims-mode ERS calls `jwt.ParseString(..., WithVerify(false),
+//     WithValidate(false))` to extract claims — it does not re-verify — so an
+//     unsigned representation is a safe and cheap bridge. The RAR endpoint
+//     has already enforced trust on the CWT signature.
+//
+// Refresh and caching of the COSE Key Set is bounded by CacheTTL.
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/veraison/go-cose"
+
+	"github.com/opentdf/platform/service/logger"
+)
+
+// CWT integer claim labels (RFC 8392 §4) and other small constants. Centralized
+// to keep the per-label switch readable and to silence the magic-number lint.
+const (
+	cwtLabelIss = 1
+	cwtLabelSub = 2
+	cwtLabelAud = 3
+	cwtLabelExp = 4
+	cwtLabelNbf = 5
+	cwtLabelIat = 6
+	cwtLabelCti = 7
+	cwtLabelCnf = 8
+
+	// COSE Key Set labels (RFC 9052 §7) for EC2 keys.
+	coseKeyLabelKty = 1
+	coseKeyLabelKid = 2
+	coseKeyLabelAlg = 3
+	coseKeyLabelCrv = -1
+	coseKeyLabelX   = -2
+	coseKeyLabelY   = -3
+	coseKtyEC2      = 2
+	coseCrvP256     = 1
+
+	// CWT CBOR tag (RFC 8392 §6) is encoded as the 2-byte prefix 0xd8, 0x3d.
+	cwtCBORTagHeaderLen = 2
+
+	// algorithmES256 is the only COSE algorithm the verifier supports today.
+	algorithmES256     = "ES256"
+	defaultCWTCacheTTL = 10 * time.Minute
+)
+
+// CWTSubjectTokenVerifier verifies a CWT subject token presented to the RAR
+// endpoint. Returns the verified claims as a jwt.Token (for the RAR
+// endpoint's own use) and an unsigned-JWT string suitable for the
+// claims-mode ERS to parse.
+type CWTSubjectTokenVerifier interface {
+	VerifyCWTSubjectToken(ctx context.Context, subjectToken string) (jwt.Token, string, error)
+}
+
+// CWTVerifierConfig is the verifier's runtime configuration. Mirrors the
+// authorization-service config struct of the same name but lives here so
+// the auth package has no dependency on the authorization package.
+type CWTVerifierConfig struct {
+	COSEKeysURL string
+	Issuer      string
+	Audience    string
+	Algorithm   string        // currently only "ES256"
+	CacheTTL    time.Duration // how long to cache the fetched key set
+	// HTTPClient is overridable for tests. Defaults to http.DefaultClient.
+	HTTPClient *http.Client
+}
+
+// CWTVerifier is the concrete CWTSubjectTokenVerifier implementation.
+type CWTVerifier struct {
+	cfg CWTVerifierConfig
+	log *logger.Logger
+
+	mu        sync.RWMutex
+	cachedAt  time.Time
+	cachedSet []coseEC2Key
+}
+
+// NewCWTVerifier constructs a verifier from config. Performs an eager fetch
+// of the COSE Key Set so misconfiguration fails fast at startup. Errors are
+// not fatal for the cache (the verifier will retry on demand) but invalid
+// algorithms or empty issuer/audience are.
+func NewCWTVerifier(ctx context.Context, cfg CWTVerifierConfig, log *logger.Logger) (*CWTVerifier, error) {
+	if cfg.COSEKeysURL == "" {
+		return nil, errors.New("cwt verifier: cose_keys_url is required")
+	}
+	if cfg.Issuer == "" {
+		return nil, errors.New("cwt verifier: issuer is required")
+	}
+	if cfg.Audience == "" {
+		return nil, errors.New("cwt verifier: audience is required")
+	}
+	if cfg.Algorithm == "" {
+		cfg.Algorithm = algorithmES256
+	}
+	if cfg.Algorithm != algorithmES256 {
+		return nil, fmt.Errorf("cwt verifier: unsupported algorithm %q (only ES256 today)", cfg.Algorithm)
+	}
+	if cfg.CacheTTL <= 0 {
+		cfg.CacheTTL = defaultCWTCacheTTL
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+
+	v := &CWTVerifier{cfg: cfg, log: log}
+	// Eager fetch — if the URL is unreachable we want startup to log it; an
+	// error here doesn't prevent the verifier from being constructed because
+	// the cache is refreshed lazily on first use, but we surface the warning.
+	if _, err := v.keys(ctx); err != nil && log != nil {
+		log.WarnContext(ctx, "initial COSE key set fetch failed; will retry on first verification",
+			slog.String("url", cfg.COSEKeysURL),
+			slog.Any("error", err),
+		)
+	}
+	return v, nil
+}
+
+// VerifyCWTSubjectToken verifies the base64url-encoded CWT and returns the
+// verified claims as both a jwt.Token (for direct use) and an unsigned-JWT
+// string (for the claims-mode ERS).
+func (v *CWTVerifier) VerifyCWTSubjectToken(ctx context.Context, subjectToken string) (jwt.Token, string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(subjectToken)
+	if err != nil {
+		// Some clients pad. Accept either form.
+		raw, err = base64.StdEncoding.DecodeString(subjectToken)
+		if err != nil {
+			return nil, "", fmt.Errorf("cwt: subject_token is not valid base64url: %w", err)
+		}
+	}
+
+	// CWTs may be wrapped in CBOR tag #61 (RFC 8392 §6); strip the 2-byte
+	// tag header if present so go-cose sees the bare COSE_Sign1.
+	if len(raw) >= cwtCBORTagHeaderLen && raw[0] == 0xd8 && raw[1] == 0x3d {
+		raw = raw[cwtCBORTagHeaderLen:]
+	}
+
+	var msg cose.Sign1Message
+	if err := msg.UnmarshalCBOR(raw); err != nil {
+		return nil, "", fmt.Errorf("cwt: not a COSE_Sign1: %w", err)
+	}
+
+	keys, err := v.keys(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("cwt: cannot fetch COSE Key Set: %w", err)
+	}
+
+	kid, _ := msg.Headers.Protected[cose.HeaderLabelKeyID].([]byte)
+	if kid == nil {
+		// Try unprotected header as a fallback.
+		kid, _ = msg.Headers.Unprotected[cose.HeaderLabelKeyID].([]byte)
+	}
+
+	verifierFound := false
+	for _, k := range keys {
+		if len(kid) > 0 && !bytesEqual(k.kid, kid) {
+			continue
+		}
+		ecdsaKey, err := k.toECDSA()
+		if err != nil {
+			continue
+		}
+		coseVerifier, err := cose.NewVerifier(cose.AlgorithmES256, ecdsaKey)
+		if err != nil {
+			continue
+		}
+		if err := msg.Verify(nil, coseVerifier); err == nil {
+			verifierFound = true
+			break
+		}
+	}
+	if !verifierFound {
+		return nil, "", errors.New("cwt: signature does not verify against any cached COSE key")
+	}
+
+	claims, err := decodeCWTClaims(msg.Payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("cwt: decode claims: %w", err)
+	}
+
+	if err := v.validateStandardClaims(claims); err != nil {
+		return nil, "", err
+	}
+
+	tok, err := claimsToJWTToken(claims)
+	if err != nil {
+		return nil, "", fmt.Errorf("cwt: build jwt.Token: %w", err)
+	}
+	unsigned, err := encodeUnsignedJWT(claims)
+	if err != nil {
+		return nil, "", fmt.Errorf("cwt: encode unsigned JWT: %w", err)
+	}
+	return tok, unsigned, nil
+}
+
+// validateStandardClaims enforces iss / aud / exp / nbf per RFC 8392 §3.
+func (v *CWTVerifier) validateStandardClaims(c map[string]any) error {
+	if iss, _ := c["iss"].(string); iss != v.cfg.Issuer {
+		return fmt.Errorf("cwt: iss mismatch (got %q, want %q)", iss, v.cfg.Issuer)
+	}
+	if !audienceContains(c["aud"], v.cfg.Audience) {
+		return fmt.Errorf("cwt: aud does not contain %q", v.cfg.Audience)
+	}
+	now := time.Now().Unix()
+	if exp, ok := claimInt64(c["exp"]); ok && now >= exp {
+		return errors.New("cwt: token expired")
+	}
+	if nbf, ok := claimInt64(c["nbf"]); ok && now < nbf {
+		return errors.New("cwt: token not yet valid")
+	}
+	return nil
+}
+
+// keys returns the currently cached COSE Key Set, refreshing it from
+// cose_keys_url if the cache is stale or empty.
+func (v *CWTVerifier) keys(ctx context.Context) ([]coseEC2Key, error) {
+	v.mu.RLock()
+	if len(v.cachedSet) > 0 && time.Since(v.cachedAt) < v.cfg.CacheTTL {
+		defer v.mu.RUnlock()
+		return v.cachedSet, nil
+	}
+	v.mu.RUnlock()
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	// Double-check after acquiring the write lock.
+	if len(v.cachedSet) > 0 && time.Since(v.cachedAt) < v.cfg.CacheTTL {
+		return v.cachedSet, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.cfg.COSEKeysURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/cose-key-set+cbor")
+	resp, err := v.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cose key set fetch returned %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	set, err := decodeCOSEKeySet(body)
+	if err != nil {
+		return nil, err
+	}
+	v.cachedSet = set
+	v.cachedAt = time.Now()
+	return set, nil
+}
+
+// --- CWT claims decoding -----------------------------------------------------
+
+// decodeCWTClaims parses a CBOR claims map (RFC 8392 §3) into a string-keyed
+// Go map suitable for downstream JWT serialization. Standard integer-label
+// claims are renamed to their JWT equivalents.
+func decodeCWTClaims(payload []byte) (map[string]any, error) {
+	var generic map[any]any
+	if err := cbor.Unmarshal(payload, &generic); err != nil {
+		return nil, err
+	}
+	out := make(map[string]any, len(generic))
+	for k, v := range generic {
+		switch key := k.(type) {
+		case int64:
+			name, ok := cwtIntLabelToName(key)
+			if !ok {
+				out["cwt:"+strconv.FormatInt(key, 10)] = normalizeCBOR(v)
+				continue
+			}
+			out[name] = normalizeCBOR(v)
+		case uint64:
+			name, ok := cwtIntLabelToName(int64(key))
+			if !ok {
+				out["cwt:"+strconv.FormatUint(key, 10)] = normalizeCBOR(v)
+				continue
+			}
+			out[name] = normalizeCBOR(v)
+		case string:
+			out[key] = normalizeCBOR(v)
+		default:
+			// Unknown key type — skip.
+		}
+	}
+	// `cti` (label 7) is bytes; surface as base64url so it survives JSON.
+	if cti, ok := out["cti"].([]byte); ok {
+		out["cti"] = base64.RawURLEncoding.EncodeToString(cti)
+	}
+	// `jti` is the JWT equivalent of cti; populate both for compatibility.
+	if _, hasCti := out["cti"]; hasCti {
+		if _, hasJti := out["jti"]; !hasJti {
+			out["jti"] = out["cti"]
+		}
+	}
+	return out, nil
+}
+
+// cwtIntLabelToName maps CWT integer claim labels (RFC 8392 §4) to JWT
+// claim names so downstream code can read them with familiar keys.
+func cwtIntLabelToName(label int64) (string, bool) {
+	switch label {
+	case cwtLabelIss:
+		return "iss", true
+	case cwtLabelSub:
+		return "sub", true
+	case cwtLabelAud:
+		return "aud", true
+	case cwtLabelExp:
+		return "exp", true
+	case cwtLabelNbf:
+		return "nbf", true
+	case cwtLabelIat:
+		return "iat", true
+	case cwtLabelCti:
+		return "cti", true
+	case cwtLabelCnf:
+		return "cnf", true
+	default:
+		return "", false
+	}
+}
+
+// normalizeCBOR converts the CBOR generic types (map[any]any, []any with
+// int64 / uint64 / []byte / string elements) into Go-idiomatic types
+// (map[string]any, []any) so json.Marshal produces sensible output.
+func normalizeCBOR(v any) any {
+	switch x := v.(type) {
+	case map[any]any:
+		m := make(map[string]any, len(x))
+		for k, vv := range x {
+			switch key := k.(type) {
+			case string:
+				m[key] = normalizeCBOR(vv)
+			case int64:
+				m[strconv.FormatInt(key, 10)] = normalizeCBOR(vv)
+			case uint64:
+				m[strconv.FormatUint(key, 10)] = normalizeCBOR(vv)
+			}
+		}
+		return m
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = normalizeCBOR(e)
+		}
+		return out
+	case uint64:
+		return int64(x)
+	default:
+		return v
+	}
+}
+
+// --- unsigned JWT bridge -----------------------------------------------------
+
+// encodeUnsignedJWT serializes the claims map as an alg=none JWT
+// (`base64url(header).base64url(claims).`). The claims-mode ERS parses with
+// `jwt.WithVerify(false)`, so an unsigned representation is the cheapest
+// safe bridge from a verified CWT to the existing JWT-shaped pipeline.
+func encodeUnsignedJWT(claims map[string]any) (string, error) {
+	header := `{"alg":"none","typ":"JWT"}`
+	body, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString([]byte(header)) +
+		"." + base64.RawURLEncoding.EncodeToString(body) +
+		".", nil
+}
+
+// claimsToJWTToken hydrates a jwt.Token from the JSON-shaped claims map.
+func claimsToJWTToken(claims map[string]any) (jwt.Token, error) {
+	body, err := json.Marshal(claims)
+	if err != nil {
+		return nil, err
+	}
+	tok, err := jwt.Parse(body, jwt.WithVerify(false), jwt.WithValidate(false))
+	if err != nil {
+		return nil, err
+	}
+	return tok, nil
+}
+
+// --- COSE Key Set decoding ---------------------------------------------------
+
+// coseEC2Key is the subset of an RFC 9052 COSE_Key (EC2) we use. The
+// platform only needs the public coordinates to build an *ecdsa.PublicKey.
+type coseEC2Key struct {
+	kid []byte
+	x   *big.Int
+	y   *big.Int
+	crv elliptic.Curve
+}
+
+func (k coseEC2Key) toECDSA() (*ecdsa.PublicKey, error) {
+	if k.x == nil || k.y == nil || k.crv == nil {
+		return nil, errors.New("incomplete EC2 key")
+	}
+	return &ecdsa.PublicKey{Curve: k.crv, X: k.x, Y: k.y}, nil
+}
+
+// decodeCOSEKeySet parses a COSE Key Set per RFC 9052 §7 — a CBOR array of
+// COSE_Keys. Only EC2 (kty=2) keys on P-256 are returned today; other key
+// types are silently skipped.
+func decodeCOSEKeySet(payload []byte) ([]coseEC2Key, error) {
+	var raw []map[int64]any
+	if err := cbor.Unmarshal(payload, &raw); err != nil {
+		return nil, fmt.Errorf("cbor decode COSE Key Set: %w", err)
+	}
+	out := make([]coseEC2Key, 0, len(raw))
+	for _, m := range raw {
+		key, ok := parseCOSEEC2Key(m)
+		if !ok {
+			continue
+		}
+		out = append(out, key)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("COSE Key Set contains no usable EC2 P-256 keys")
+	}
+	return out, nil
+}
+
+func parseCOSEEC2Key(m map[int64]any) (coseEC2Key, bool) {
+	kty, _ := claimInt64(m[coseKeyLabelKty])
+	if kty != coseKtyEC2 {
+		return coseEC2Key{}, false
+	}
+	crvLabel, _ := claimInt64(m[coseKeyLabelCrv])
+	var curve elliptic.Curve
+	switch crvLabel {
+	case coseCrvP256:
+		curve = elliptic.P256()
+	default:
+		return coseEC2Key{}, false
+	}
+	xBytes, _ := m[coseKeyLabelX].([]byte)
+	yBytes, _ := m[coseKeyLabelY].([]byte)
+	if len(xBytes) == 0 || len(yBytes) == 0 {
+		return coseEC2Key{}, false
+	}
+	kid, _ := m[coseKeyLabelKid].([]byte)
+	return coseEC2Key{
+		kid: kid,
+		x:   new(big.Int).SetBytes(xBytes),
+		y:   new(big.Int).SetBytes(yBytes),
+		crv: curve,
+	}, true
+}
+
+// --- small helpers -----------------------------------------------------------
+
+func claimInt64(v any) (int64, bool) {
+	switch x := v.(type) {
+	case int64:
+		return x, true
+	case uint64:
+		return int64(x), true
+	case int:
+		return int64(x), true
+	case float64:
+		return int64(x), true
+	default:
+		return 0, false
+	}
+}
+
+func audienceContains(claim any, want string) bool {
+	switch x := claim.(type) {
+	case string:
+		return x == want
+	case []any:
+		for _, e := range x {
+			if s, ok := e.(string); ok && s == want {
+				return true
+			}
+		}
+	case []string:
+		for _, s := range x {
+			if s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/service/internal/auth/cwt_verifier_test.go
+++ b/service/internal/auth/cwt_verifier_test.go
@@ -1,0 +1,335 @@
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/go-cose"
+)
+
+// --- helpers ----------------------------------------------------------------
+
+// newP256 returns a fresh ECDSA P-256 keypair plus the RFC 7638-style
+// thumbprint we use as a kid throughout the tests.
+func newP256(t *testing.T) (*ecdsa.PrivateKey, []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	kid := append([]byte("kid-"), byteSlicePad(priv.X.Bytes(), 4)...)
+	return priv, kid
+}
+
+func byteSlicePad(b []byte, n int) []byte {
+	if len(b) >= n {
+		return b[:n]
+	}
+	out := make([]byte, n)
+	copy(out[n-len(b):], b)
+	return out
+}
+
+// coseKeySetFromPub serializes a P-256 public key as a one-entry COSE Key
+// Set CBOR (matching what authnz-rs publishes at /.well-known/cose-keys).
+func coseKeySetFromPub(t *testing.T, pub *ecdsa.PublicKey, kid []byte) []byte {
+	t.Helper()
+	x := byteSlicePad(pub.X.Bytes(), 32)
+	y := byteSlicePad(pub.Y.Bytes(), 32)
+	key := map[int64]any{
+		1:  int64(2),  // kty = EC2
+		3:  int64(-7), // alg = ES256
+		-1: int64(1),  // crv = P-256
+		-2: x,
+		-3: y,
+		2:  kid, // kid
+	}
+	buf, err := cbor.Marshal([]map[int64]any{key})
+	require.NoError(t, err)
+	return buf
+}
+
+// signCWT signs a CWT with claims and returns base64url(COSE_Sign1) — the
+// same wire format the RAR endpoint will accept as a subject_token.
+func signCWT(t *testing.T, priv *ecdsa.PrivateKey, kid []byte, claims map[int64]any, custom map[string]any) string {
+	t.Helper()
+	// Encode claims as CBOR.
+	payload := map[any]any{}
+	for k, v := range claims {
+		payload[k] = v
+	}
+	for k, v := range custom {
+		payload[k] = v
+	}
+	payloadCBOR, err := cbor.Marshal(payload)
+	require.NoError(t, err)
+
+	signer, err := cose.NewSigner(cose.AlgorithmES256, priv)
+	require.NoError(t, err)
+	msg := cose.Sign1Message{
+		Headers: cose.Headers{
+			Protected: cose.ProtectedHeader{
+				cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
+				cose.HeaderLabelKeyID:     kid,
+			},
+		},
+		Payload: payloadCBOR,
+	}
+	require.NoError(t, msg.Sign(rand.Reader, nil, signer))
+	raw, err := msg.MarshalCBOR()
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// keySetServer wraps a tiny httptest.Server that serves a COSE Key Set,
+// mimicking authnz-rs's /.well-known/cose-keys.
+func keySetServer(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/cose-key-set+cbor")
+		_, _ = w.Write(body)
+	}))
+}
+
+// standardClaims builds a CWT claims map with CBOR integer labels
+// (RFC 8392 §4) for the standard registered claims used in tests.
+// `sub` is parameterized for future tests even though every existing test
+// uses "user-1".
+//
+//nolint:unparam // sub is intentionally parameterizable
+func standardClaims(iss, aud, sub string, ttl time.Duration) map[int64]any {
+	now := time.Now().Unix()
+	return map[int64]any{
+		1: iss,                        // iss
+		2: sub,                        // sub
+		3: aud,                        // aud
+		4: now + int64(ttl.Seconds()), // exp
+		6: now,                        // iat
+	}
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestCWTVerifier_HappyPath(t *testing.T) {
+	priv, kid := newP256(t)
+	keySet := coseKeySetFromPub(t, &priv.PublicKey, kid)
+	srv := keySetServer(t, keySet)
+	defer srv.Close()
+
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		Algorithm:   "ES256",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+
+	subjectToken := signCWT(t, priv, kid,
+		standardClaims("https://idp.example", "opentdf-platform", "user-1", time.Hour),
+		map[string]any{
+			"email":             "alice@example.com",
+			"arkavo_roles":      []any{"user", "reader"},
+			"arkavo_account_id": "acct-1234",
+		},
+	)
+	tok, jwtStr, err := v.VerifyCWTSubjectToken(context.Background(), subjectToken)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	require.Equal(t, "user-1", tok.Subject())
+	require.NotEmpty(t, jwtStr)
+	// Synthetic JWT is alg=none → ends with the trailing dot.
+	require.Equal(t, byte('.'), jwtStr[len(jwtStr)-1])
+}
+
+func TestCWTVerifier_RejectsWrongIssuer(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	tok := signCWT(t, priv, kid,
+		standardClaims("https://imposter.example", "opentdf-platform", "user-1", time.Hour),
+		nil,
+	)
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), tok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "iss mismatch")
+}
+
+func TestCWTVerifier_RejectsWrongAudience(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	tok := signCWT(t, priv, kid,
+		standardClaims("https://idp.example", "some-other-rs", "user-1", time.Hour),
+		nil,
+	)
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), tok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aud")
+}
+
+func TestCWTVerifier_RejectsExpired(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	tok := signCWT(t, priv, kid,
+		standardClaims("https://idp.example", "opentdf-platform", "user-1", -time.Minute),
+		nil,
+	)
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), tok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestCWTVerifier_RejectsUnknownKid(t *testing.T) {
+	priv1, kid1 := newP256(t)
+	priv2, kid2 := newP256(t)
+	// Server publishes priv1's public key.
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv1.PublicKey, kid1))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	// Sign with priv2 and kid2 — server doesn't know it.
+	tok := signCWT(t, priv2, kid2,
+		standardClaims("https://idp.example", "opentdf-platform", "user-1", time.Hour),
+		nil,
+	)
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), tok)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verify")
+}
+
+func TestCWTVerifier_RejectsMalformedBase64(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), "!!!not base64!!!")
+	require.Error(t, err)
+}
+
+func TestCWTVerifier_RejectsMalformedCBOR(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	// Valid base64, decodes to non-COSE bytes.
+	garbage := base64.RawURLEncoding.EncodeToString([]byte("not a cose_sign1"))
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), garbage)
+	require.Error(t, err)
+}
+
+func TestCWTVerifier_CustomClaimsRoundTrip(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	subjectToken := signCWT(t, priv, kid,
+		standardClaims("https://idp.example", "opentdf-platform", "user-1", time.Hour),
+		map[string]any{
+			"arkavo_roles":        []any{"admin", "reader"},
+			"arkavo_entitlements": []any{"tdf:create", "tdf:decrypt"},
+			"arkavo_account_id":   "acct-9999",
+			"idp":                 "webauthn",
+			"email":               "bob@example.com",
+		},
+	)
+	tok, _, err := v.VerifyCWTSubjectToken(context.Background(), subjectToken)
+	require.NoError(t, err)
+
+	roles, ok := tok.Get("arkavo_roles")
+	require.True(t, ok)
+	rolesSlice, ok := roles.([]any)
+	require.True(t, ok)
+	require.Len(t, rolesSlice, 2)
+	assert.Equal(t, "admin", rolesSlice[0])
+
+	idp, ok := tok.Get("idp")
+	require.True(t, ok)
+	assert.Equal(t, "webauthn", idp)
+}
+
+func TestCWTVerifier_AudienceArrayMatches(t *testing.T) {
+	priv, kid := newP256(t)
+	srv := keySetServer(t, coseKeySetFromPub(t, &priv.PublicKey, kid))
+	defer srv.Close()
+	v, err := NewCWTVerifier(context.Background(), CWTVerifierConfig{
+		COSEKeysURL: srv.URL,
+		Issuer:      "https://idp.example",
+		Audience:    "opentdf-platform",
+		CacheTTL:    time.Minute,
+	}, nil)
+	require.NoError(t, err)
+	claims := standardClaims("https://idp.example", "", "user-1", time.Hour)
+	claims[3] = []any{"some-other-rs", "opentdf-platform"} // aud as array
+	tok := signCWT(t, priv, kid, claims, nil)
+	_, _, err = v.VerifyCWTSubjectToken(context.Background(), tok)
+	require.NoError(t, err)
+}
+
+func TestNewCWTVerifier_RejectsBadConfig(t *testing.T) {
+	cases := map[string]CWTVerifierConfig{
+		"missing url":   {Issuer: "i", Audience: "a"},
+		"missing iss":   {COSEKeysURL: "https://x", Audience: "a"},
+		"missing aud":   {COSEKeysURL: "https://x", Issuer: "i"},
+		"bad algorithm": {COSEKeysURL: "https://x", Issuer: "i", Audience: "a", Algorithm: "RS256"},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewCWTVerifier(context.Background(), c, nil)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Brings CWT support to the platform's RFC 8693 token-exchange endpoint **in both directions**, so a Rust PEP can ride a single COSE/CBOR pipeline end-to-end without ever touching JWT.

Two commits in this PR (the second was previously PR #14, merged in for review convenience):

1. **`ae86a373` — accept CWT subject tokens.** New `subject_token_type=urn:ietf:params:oauth:token-type:cwt`; verifier fetches the IdP's COSE Key Set from `/.well-known/cose-keys` (authnz-rs publishes one), verifies COSE_Sign1 / ES256, validates `iss`/`aud`/`exp`/`nbf` per RFC 8392, decodes claims, and bridges to the existing claims-mode ERS via a synthetic alg=none JWT. Opt-in via config.
2. **`f6110427` — emit CWT access tokens by default.** New `RARCWTSigner` (ephemeral ES256), CWT becomes the default response (raw CBOR body, `Content-Type: application/cwt+cbor`); JWT path stays as opt-in via `requested_token_type=urn:ietf:params:oauth:token-type:jwt`. New endpoint `GET /v2/authorization/cose-keys` publishes the signer's public key as a CBOR COSE Key Set — same shape authnz-rs serves, so PEPs reuse one verifier.

## End-to-end wire shape

```
authnz-rs                opentdf-platform                Rust PEP
   │                            │                          │
   │── CWT subject_token ──────►│                          │
   │   (POST /v2/authorization/ │                          │
   │    token)                  │                          │
   │                            │                          │
   │   verify against authnz-rs │                          │
   │   /.well-known/cose-keys   │                          │
   │                            │── CWT response (CBOR) ──►│
   │                            │   Content-Type:           │
   │                            │   application/cwt+cbor    │
   │                            │                          │
   │                            │                          │── verify against
   │                            │                          │   /v2/authorization/
   │                            │                          │   cose-keys
   │                            │                          │   ↓
   │                            │                          │ AccessPdp::check
```

No JWT hops. Same COSE verifier code path for both directions.

## CWT payload shape (RFC 8392)

| Label | Claim | Notes |
|---|---|---|
| `1` | `iss` | configured issuer |
| `2` | `sub` | entity subject |
| `3` | `aud` | omitted if absent |
| `4` | `exp` / `5` `nbf` / `6` `iat` | unix seconds |
| `7` | `cti` | 16-byte UUID |
| `"authorization_details"` (text label) | RFC 9396 grant array | text-keyed maps: `type`/`actions`/`locations`/`obligations` — mirrors the JSON shape so existing `local.Grant` consumers read the same fields |

## API changes

- **Subject side**: new accepted `subject_token_type=urn:ietf:params:oauth:token-type:cwt`. Opt-in via new `rar.cwt_verifier` config block.
- **Response side**: default `requested_token_type` flips from JWT to **CWT**. ⚠️ **Breaking** for clients that depended on the JSON envelope without setting `requested_token_type` — mitigation is to add `requested_token_type=urn:ietf:params:oauth:token-type:jwt` to existing request forms.
- **New endpoint**: `GET /v2/authorization/cose-keys` returns the response signer's public COSE Key Set as CBOR.

## Config

```yaml
server:
  authorization:
    rar:
      enabled: true
      cwt_verifier:                      # subject-side CWT verification (opt-in)
        enabled: true
        cose_keys_url: https://authnz.example/.well-known/cose-keys
        issuer: https://authnz.example
        audience: opentdf-platform
        algorithm: ES256
        cache_ttl: 10m
      # CWT response signing is on whenever rar.enabled is true; falls back
      # to JWT-only if the CWT signer fails to construct.
```

## Dependencies added

- `github.com/veraison/go-cose v1.3.0` — COSE_Sign1 verify + sign (MIT, mature)
- `github.com/fxamacker/cbor/v2 v2.9.2` — CBOR encode/decode (MIT)

## Tests

15 tests total across two new files:

**`service/internal/auth/cwt_verifier_test.go`** (9 verifier tests):
happy path, wrong issuer, wrong audience, expired, unknown kid, malformed base64, malformed CBOR, custom-claim round-trip, audience-as-array.

**`service/authorization/v2/rar_cwt_test.go`** (4 subject-token integration tests):
full flow through the endpoint producing real `authorization_details`; bad-signature reject; 400 when verifier not configured; malformed-base64 reject.

**`service/authorization/v2/rar_cwt_response_test.go`** (6 response-token integration tests):
default-is-CWT (no `requested_token_type` set), response signature verifies against published `/v2/authorization/cose-keys`, signer-absent graceful 400, COSE keys endpoint shape, JWT opt-in still works, unknown `requested_token_type` rejected.

All pre-existing tests still pass (the JSON-envelope ones were updated to opt into `requested_token_type=jwt` explicitly).

## Test plan

- [x] `go test ./authorization/v2/ ./internal/auth/` green
- [x] `go build ./...` clean
- [x] `golangci-lint run ./authorization/v2/... ./internal/auth/...` — no new issues in changed files
- [x] Manual round-trip: subject CWT → platform → response CWT → verify against `/v2/authorization/cose-keys` (covered by `TestRAREndpoint_CWTResponse_VerifiesAgainstPublishedCOSEKeySet`)
- [ ] End-to-end with a Rust PEP — covered in `opentdf-rs` PR #78 (`examples/pep_check.rs`)

## Out of scope

- Configurable signing-key persistence (still ephemeral per process; restart rotates).
- Multi-key rotation in the published COSE Key Set.
- Removing the JWT path entirely (kept for compatibility).
- Proto change to add `entity.Token.cwt` bytes field (synthetic-JWT bridge works for the MVP).
- CWT `cnf` proof-of-possession enforcement (RFC 8747). The verifier surfaces `cnf` claims but does not require a PoP ceremony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)