### PR TITLE
feat(authz): emit CWT access tokens by default at /v2/authorization/token

### DIFF
--- a/service/authorization/v2/authorization.go
+++ b/service/authorization/v2/authorization.go
@@ -159,16 +159,27 @@ func buildRARHandler(svc *Service, cfg *Config, srp serviceregistry.Registration
 		srp.Logger.Error("failed to create rar signer; rar endpoint will be disabled", slog.Any("error", err))
 		return nil
 	}
+	// Mint a parallel CWT signer alongside the JWT one. Failure here only
+	// disables the CWT response path; the JWT-explicit path keeps working.
+	cwtSigner, err := NewEphemeralRARCWTSigner(cfg.RAR.Issuer, ttl)
+	if err != nil {
+		srp.Logger.Error("failed to create rar CWT signer; CWT responses will be disabled",
+			slog.Any("error", err))
+		cwtSigner = nil
+	}
 	srp.Logger.Info("rar token endpoint enabled",
 		slog.String("issuer", cfg.RAR.Issuer),
 		slog.String("token_ttl", ttl.String()),
 		slog.String("token_path", rarTokenPath),
 		slog.String("jwks_path", rarJWKSPath),
+		slog.String("cose_keys_path", rarCOSEKeysPath),
+		slog.Bool("cwt_responses_enabled", cwtSigner != nil),
 	)
 	endpoint := &RAREndpoint{
-		pdp:      svc,
-		signer:   signer,
-		verifier: srp.AccessTokenVerifier,
+		pdp:       svc,
+		signer:    signer,
+		cwtSigner: cwtSigner,
+		verifier:  srp.AccessTokenVerifier,
 	}
 
 	// Optional CWT subject-token verifier. Off by default; enabled when an

--- a/service/authorization/v2/rar.go
+++ b/service/authorization/v2/rar.go
@@ -61,8 +61,11 @@ const (
 	// JWT-family subject token types.
 	tokenTypeCWT = "urn:ietf:params:oauth:token-type:cwt" //nolint:gosec // RFC 8392 / RFC 8693 token type URN
 
-	rarTokenPath = "/v2/authorization/token"
-	rarJWKSPath  = "/v2/authorization/jwks.json"
+	rarTokenPath     = "/v2/authorization/token"
+	rarJWKSPath      = "/v2/authorization/jwks.json"
+	rarCOSEKeysPath  = "/v2/authorization/cose-keys"
+	contentTypeCWT   = "application/cwt+cbor"
+	contentTypeCOSEK = "application/cose-key-set+cbor"
 )
 
 // authzDetailRequest is a parsed authorization_details entry from the inbound
@@ -103,14 +106,36 @@ type rarErrorResponse struct {
 type RAREndpoint struct {
 	pdp         *Service
 	signer      *RARSigner
+	cwtSigner   *RARCWTSigner
 	verifier    authn.AccessTokenVerifier
 	cwtVerifier authn.CWTSubjectTokenVerifier
 }
 
-// Mount attaches the RAR token + JWKS handlers to the supplied mux.
+// Mount attaches the RAR token + JWKS + COSE Key Set handlers to the
+// supplied mux. The COSE Key Set is only published when a CWT signer is
+// configured; without it the route returns 503.
 func (r *RAREndpoint) Mount(mux *http.ServeMux) {
 	mux.HandleFunc("POST "+rarTokenPath, r.handleToken)
 	mux.HandleFunc("GET "+rarJWKSPath, r.handleJWKS)
+	mux.HandleFunc("GET "+rarCOSEKeysPath, r.handleCOSEKeys)
+}
+
+func (r *RAREndpoint) handleCOSEKeys(w http.ResponseWriter, _ *http.Request) {
+	if r.cwtSigner == nil {
+		writeError(w, http.StatusServiceUnavailable, "server_error",
+			"CWT signer not configured")
+		return
+	}
+	set, err := r.cwtSigner.COSEKeySet()
+	if err != nil {
+		r.pdp.logger.Error("failed to encode COSE Key Set", slog.Any("error", err))
+		writeError(w, http.StatusInternalServerError, "server_error",
+			"could not encode COSE Key Set")
+		return
+	}
+	w.Header().Set("Content-Type", contentTypeCOSEK)
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write(set)
 }
 
 func (r *RAREndpoint) handleJWKS(w http.ResponseWriter, _ *http.Request) {
@@ -163,13 +188,27 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 			"unsupported subject_token_type "+subjectTokenType)
 		return
 	}
+	// requested_token_type controls the response format. Default is CWT —
+	// the platform issues authorization_details inside an RFC 8392 CWT
+	// (COSE_Sign1 / ES256) and the response body is raw CBOR with content
+	// type application/cwt+cbor. Clients can opt back into the legacy JSON
+	// envelope by setting requested_token_type to the JWT URN.
 	requestedTokenType := req.PostForm.Get("requested_token_type")
 	if requestedTokenType == "" {
-		requestedTokenType = tokenTypeJWT
+		requestedTokenType = tokenTypeCWT
 	}
-	if requestedTokenType != tokenTypeJWT {
+	switch requestedTokenType {
+	case tokenTypeCWT:
+		if r.cwtSigner == nil {
+			writeError(w, http.StatusBadRequest, "invalid_request",
+				"CWT response tokens are not enabled on this server")
+			return
+		}
+	case tokenTypeJWT:
+		// JSON envelope path; r.signer is required (validated at startup).
+	default:
 		writeError(w, http.StatusBadRequest, "invalid_request",
-			"only "+tokenTypeJWT+" is supported as requested_token_type")
+			"unsupported requested_token_type "+requestedTokenType)
 		return
 	}
 	audience := req.PostForm.Get("audience")
@@ -246,24 +285,39 @@ func (r *RAREndpoint) handleToken(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	signed, exp, err := r.signer.Issue(subjectStr, audience, grants)
-	if err != nil {
-		r.pdp.logger.ErrorContext(ctx, "rar token sign failed", slog.Any("error", err))
-		writeError(w, http.StatusInternalServerError, "server_error", "could not mint access token")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
-	if err := json.NewEncoder(w).Encode(tokenExchangeResponse{
-		AccessToken:          signed,
-		IssuedTokenType:      tokenTypeJWT,
-		TokenType:            "Bearer",
-		ExpiresIn:            int64(time.Until(exp).Seconds()),
-		AuthorizationDetails: grants,
-	}); err != nil {
-		r.pdp.logger.Error("failed to encode rar response", slog.Any("error", err))
+	switch requestedTokenType {
+	case tokenTypeCWT:
+		raw, _, err := r.cwtSigner.Issue(subjectStr, audience, grants)
+		if err != nil {
+			r.pdp.logger.ErrorContext(ctx, "rar cwt sign failed", slog.Any("error", err))
+			writeError(w, http.StatusInternalServerError, "server_error", "could not mint CWT access token")
+			return
+		}
+		// Raw CBOR body; access_token claims (sub, aud, exp, authorization_details)
+		// live inside the CWT itself, so no JSON envelope is needed.
+		w.Header().Set("Content-Type", contentTypeCWT)
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		_, _ = w.Write(raw)
+	default: // tokenTypeJWT
+		signed, exp, err := r.signer.Issue(subjectStr, audience, grants)
+		if err != nil {
+			r.pdp.logger.ErrorContext(ctx, "rar token sign failed", slog.Any("error", err))
+			writeError(w, http.StatusInternalServerError, "server_error", "could not mint access token")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		if err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+			AccessToken:          signed,
+			IssuedTokenType:      tokenTypeJWT,
+			TokenType:            "Bearer",
+			ExpiresIn:            int64(time.Until(exp).Seconds()),
+			AuthorizationDetails: grants,
+		}); err != nil {
+			r.pdp.logger.Error("failed to encode rar response", slog.Any("error", err))
+		}
 	}
 }
 

--- a/service/authorization/v2/rar_cwt_response_test.go
+++ b/service/authorization/v2/rar_cwt_response_test.go
@@ -1,0 +1,213 @@
+package authorization
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/opentdf/platform/service/access/local"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/go-cose"
+)
+
+// --- helpers ----------------------------------------------------------------
+
+// stripCWTTag drops the optional RFC 8392 §6 CWT tag prefix (0xd8, 0x3d)
+// so go-cose can parse the bare COSE_Sign1.
+func stripCWTTag(b []byte) []byte {
+	if len(b) >= 2 && b[0] == 0xd8 && b[1] == 0x3d {
+		return b[2:]
+	}
+	return b
+}
+
+// fetchCOSEKeySet pulls and parses the platform's published COSE Key Set
+// the same way an external PEP would.
+func fetchCOSEKeySet(t *testing.T, baseURL string) []*ecdsa.PublicKey {
+	t.Helper()
+	resp, err := http.Get(baseURL + rarCOSEKeysPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, contentTypeCOSEK, resp.Header.Get("Content-Type"))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var keys []map[int64]any
+	require.NoError(t, cbor.Unmarshal(body, &keys))
+	require.NotEmpty(t, keys)
+
+	out := make([]*ecdsa.PublicKey, 0, len(keys))
+	for _, k := range keys {
+		x, _ := k[coseXLabel].([]byte)
+		y, _ := k[coseYLabel].([]byte)
+		require.NotEmpty(t, x)
+		require.NotEmpty(t, y)
+		out = append(out, ecKeyFromXY(x, y))
+	}
+	return out
+}
+
+func ecKeyFromXY(x, y []byte) *ecdsa.PublicKey {
+	key := &ecdsa.PublicKey{Curve: elliptic.P256()}
+	key.X = new(big.Int).SetBytes(x)
+	key.Y = new(big.Int).SetBytes(y)
+	return key
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestRAREndpoint_CWTResponse_IsDefault(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	// Build a form with NO requested_token_type — the new default is CWT.
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("audience", "kas.example")
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, contentTypeCWT, resp.Header.Get("Content-Type"))
+
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// Verify the response is a real, signed COSE_Sign1 we can decode.
+	cose1 := stripCWTTag(raw)
+	var msg cose.Sign1Message
+	require.NoError(t, msg.UnmarshalCBOR(cose1))
+
+	// Decode the payload as a CBOR map and assert the standard claims plus
+	// authorization_details are present.
+	var claims map[any]any
+	require.NoError(t, cbor.Unmarshal(msg.Payload, &claims))
+	assert.Equal(t, "https://opentdf.local", claims[uint64(cwtClaimIss)])
+	assert.Equal(t, "user-1", claims[uint64(cwtClaimSub)])
+	assert.Equal(t, "kas.example", claims[uint64(cwtClaimAud)])
+	details, ok := claims[local.AuthorizationDetailsClaim].([]any)
+	require.True(t, ok, "expected authorization_details array, got %T", claims[local.AuthorizationDetailsClaim])
+	require.NotEmpty(t, details)
+}
+
+func TestRAREndpoint_CWTResponse_VerifiesAgainstPublishedCOSEKeySet(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+
+	var msg cose.Sign1Message
+	require.NoError(t, msg.UnmarshalCBOR(stripCWTTag(body)))
+
+	// Pull keys from the platform's published COSE Key Set and verify the
+	// response signature with one of them — proves the same key pair signs
+	// the token and answers the COSE key endpoint.
+	pubKeys := fetchCOSEKeySet(t, srv.URL)
+	require.NotEmpty(t, pubKeys)
+
+	verified := false
+	for _, k := range pubKeys {
+		v, err := cose.NewVerifier(cose.AlgorithmES256, k)
+		require.NoError(t, err)
+		if err := msg.Verify(nil, v); err == nil {
+			verified = true
+			break
+		}
+	}
+	assert.True(t, verified, "no published COSE key verified the response signature")
+}
+
+func TestRAREndpoint_CWTResponse_DisabledWhenSignerMissing(t *testing.T) {
+	// Build an endpoint with a JWT signer but no CWT signer — CWT response
+	// must fall through to 400.
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+	endpoint.cwtSigner = nil // simulate "CWT signer failed at startup"
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeCWT)
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRAREndpoint_COSEKeysEndpoint(t *testing.T) {
+	endpoint, _ := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + rarCOSEKeysPath)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, contentTypeCOSEK, resp.Header.Get("Content-Type"))
+}
+
+func TestRAREndpoint_JWTResponse_OptIn(t *testing.T) {
+	// Clients explicitly asking for JWT keep getting the JSON envelope.
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeJWT)
+
+	body := doTokenRequest(t, srv.URL, form)
+	require.NotEmpty(t, body.AccessToken)
+	require.Equal(t, "Bearer", body.TokenType)
+	require.Equal(t, tokenTypeJWT, body.IssuedTokenType)
+}
+
+func TestRAREndpoint_UnknownRequestedTokenTypeRejected(t *testing.T) {
+	endpoint, subjectToken := newTestEndpoint(t, "topsecret")
+	srv := newServer(endpoint)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", grantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", "urn:bogus:token-type")
+
+	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/service/authorization/v2/rar_cwt_signer.go
+++ b/service/authorization/v2/rar_cwt_signer.go
@@ -1,0 +1,218 @@
+// Package authorization — RAR CWT signer.
+//
+// Mints RFC 8392 CWTs (COSE_Sign1 / ES256) carrying the materialized RFC 9396
+// authorization_details payload. Mirrors RARSigner but emits CBOR instead of
+// JWT/JWS so consumers that prefer CWT throughout (e.g. an authnz-rs-issued
+// CWT subject token round-tripping back as a CWT access token) don't have to
+// straddle two encodings.
+//
+// Wire shape:
+//
+//	CWT payload (CBOR map):
+//	  1 (iss):  configured issuer
+//	  2 (sub):  entity subject string
+//	  3 (aud):  caller-supplied audience (omitted if empty)
+//	  4 (exp):  unix seconds
+//	  5 (nbf):  unix seconds
+//	  6 (iat):  unix seconds
+//	  7 (cti):  16-byte UUID
+//	  "authorization_details": [ {type, actions[], locations[], obligations[]}, ... ]
+//
+// Signing key is an ephemeral ES256 (P-256) keypair generated at construction.
+// The public half is published via COSEKeySet() — the COSE Key Set CBOR shape
+// authnz-rs already serves at /.well-known/cose-keys, so PEPs can use one
+// verifier code path for both the subject-side and access-side tokens.
+package authorization
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+	"github.com/google/uuid"
+	"github.com/veraison/go-cose"
+
+	"github.com/opentdf/platform/service/access/local"
+)
+
+// COSE Key Set labels (RFC 9052 §7) used when building the published key.
+const (
+	coseKtyLabel = 1
+	coseKidLabel = 2
+	coseAlgLabel = 3
+	coseCrvLabel = -1
+	coseXLabel   = -2
+	coseYLabel   = -3
+	coseKtyEC2   = 2
+	coseAlgES256 = -7
+	coseCrvP256  = 1
+)
+
+// CWT integer claim labels (RFC 8392 §4).
+const (
+	cwtClaimIss = 1
+	cwtClaimSub = 2
+	cwtClaimAud = 3
+	cwtClaimExp = 4
+	cwtClaimNbf = 5
+	cwtClaimIat = 6
+	cwtClaimCti = 7
+)
+
+// p256CoordLen is the byte length of an X9.62 P-256 coordinate.
+const p256CoordLen = 32
+
+// ErrCWTSignerNotConfigured is returned when the RAR endpoint is asked for a
+// CWT response token but the CWT signer was never built.
+var ErrCWTSignerNotConfigured = errors.New("rar: CWT signer not configured")
+
+// RARCWTSigner mints RFC 8392 CWTs over an ephemeral ES256 keypair. The
+// matching public key is published via COSEKeySet().
+type RARCWTSigner struct {
+	mu     sync.RWMutex
+	priv   *ecdsa.PrivateKey
+	kid    []byte
+	issuer string
+	ttl    time.Duration
+}
+
+// NewEphemeralRARCWTSigner generates a fresh ES256 (P-256) keypair and
+// returns a ready-to-use signer. The kid is a UUID, so each process gets a
+// unique signing identity (matching RARSigner's behavior).
+func NewEphemeralRARCWTSigner(issuer string, ttl time.Duration) (*RARCWTSigner, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("rar cwt: generate signing key: %w", err)
+	}
+	kid, err := uuid.New().MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("rar cwt: marshal kid: %w", err)
+	}
+	return &RARCWTSigner{
+		priv:   priv,
+		kid:    kid,
+		issuer: issuer,
+		ttl:    ttl,
+	}, nil
+}
+
+// Issue mints a CWT carrying the supplied authorization_details grant set.
+// Returns the raw CBOR bytes of the (tagged) COSE_Sign1 plus the absolute
+// expiry time so callers can populate response framing if needed.
+func (s *RARCWTSigner) Issue(subject, audience string, grants []local.Grant) ([]byte, time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now()
+	exp := now.Add(s.ttl)
+	cti, err := uuid.New().MarshalBinary()
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: cti: %w", err)
+	}
+
+	claims := map[any]any{
+		cwtClaimIss: s.issuer,
+		cwtClaimSub: subject,
+		cwtClaimExp: exp.Unix(),
+		cwtClaimNbf: now.Unix(),
+		cwtClaimIat: now.Unix(),
+		cwtClaimCti: cti,
+	}
+	if audience != "" {
+		claims[cwtClaimAud] = audience
+	}
+	if len(grants) > 0 {
+		// authorization_details lives at a text label, matching the JSON
+		// claim name. Each grant becomes a CBOR map with string keys so a
+		// CBOR-aware PEP gets the same shape it would from JSON.
+		claims[local.AuthorizationDetailsClaim] = grantsToCBOR(grants)
+	}
+
+	payload, err := cbor.Marshal(claims)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: encode claims: %w", err)
+	}
+
+	signer, err := cose.NewSigner(cose.AlgorithmES256, s.priv)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: new signer: %w", err)
+	}
+	msg := cose.Sign1Message{
+		Headers: cose.Headers{
+			Protected: cose.ProtectedHeader{
+				cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
+				cose.HeaderLabelKeyID:     s.kid,
+			},
+		},
+		Payload: payload,
+	}
+	if err := msg.Sign(rand.Reader, nil, signer); err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: sign: %w", err)
+	}
+	raw, err := msg.MarshalCBOR()
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("rar cwt: marshal: %w", err)
+	}
+	// Wrap in CWT tag #61 per RFC 8392 §6 so naive consumers can detect the
+	// payload type without inspecting the structure.
+	tagged := append([]byte{0xd8, 0x3d}, raw...)
+	return tagged, exp, nil
+}
+
+// COSEKeySet returns the CBOR-encoded one-entry COSE Key Set (RFC 9052 §7)
+// containing this signer's public key, suitable for serving at the
+// /v2/authorization/cose-keys endpoint.
+func (s *RARCWTSigner) COSEKeySet() ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	x := padCoord(s.priv.X.Bytes())
+	y := padCoord(s.priv.Y.Bytes())
+	key := map[int64]any{
+		coseKtyLabel: int64(coseKtyEC2),
+		coseAlgLabel: int64(coseAlgES256),
+		coseCrvLabel: int64(coseCrvP256),
+		coseXLabel:   x,
+		coseYLabel:   y,
+		coseKidLabel: s.kid,
+	}
+	buf, err := cbor.Marshal([]map[int64]any{key})
+	if err != nil {
+		return nil, fmt.Errorf("rar cwt: marshal cose key set: %w", err)
+	}
+	return buf, nil
+}
+
+// grantsToCBOR converts a Grant slice to a CBOR array-of-maps with string
+// keys so the wire shape mirrors the JSON shape exactly.
+func grantsToCBOR(grants []local.Grant) []map[string]any {
+	out := make([]map[string]any, 0, len(grants))
+	for _, g := range grants {
+		m := map[string]any{
+			"type":      g.Type,
+			"actions":   g.Actions,
+			"locations": g.Locations,
+		}
+		if len(g.Obligations) > 0 {
+			m["obligations"] = g.Obligations
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// padCoord left-pads an X9.62 EC coordinate to the fixed P-256 length so
+// COSE consumers don't have to handle short-form integers.
+func padCoord(b []byte) []byte {
+	if len(b) >= p256CoordLen {
+		return b[len(b)-p256CoordLen:]
+	}
+	out := make([]byte, p256CoordLen)
+	copy(out[p256CoordLen-len(b):], b)
+	return out
+}

--- a/service/authorization/v2/rar_cwt_test.go
+++ b/service/authorization/v2/rar_cwt_test.go
@@ -171,6 +171,8 @@ func newCWTTestEndpoint(t *testing.T, priv *ecdsa.PrivateKey, kid []byte) (*RARE
 	}
 	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
 	require.NoError(t, err)
+	cwtSigner, err := NewEphemeralRARCWTSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
 
 	cwtVerifier, err := authn.NewCWTVerifier(context.Background(), authn.CWTVerifierConfig{
 		COSEKeysURL: keySrv.URL,
@@ -184,6 +186,7 @@ func newCWTTestEndpoint(t *testing.T, priv *ecdsa.PrivateKey, kid []byte) (*RARE
 	endpoint := &RAREndpoint{
 		pdp:         svc,
 		signer:      signer,
+		cwtSigner:   cwtSigner,
 		cwtVerifier: cwtVerifier,
 	}
 	return endpoint, keySrv
@@ -217,6 +220,7 @@ func TestRAREndpoint_CWT_HappyPath(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 	form.Set("audience", "kas.example")
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
@@ -251,6 +255,7 @@ func TestRAREndpoint_CWT_RejectsBadSignature(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
 		strings.NewReader(form.Encode()))
@@ -269,6 +274,7 @@ func TestRAREndpoint_CWT_DisabledWhenVerifierNotConfigured(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", "any-token")
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
 		strings.NewReader(form.Encode()))
@@ -293,6 +299,7 @@ func TestRAREndpoint_CWT_RejectsMalformedBase64(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", "!!!not base64!!!")
 	form.Set("subject_token_type", tokenTypeCWT)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded",
 		strings.NewReader(form.Encode()))

--- a/service/authorization/v2/rar_test.go
+++ b/service/authorization/v2/rar_test.go
@@ -243,11 +243,14 @@ func newTestEndpoint(t *testing.T, clearance string) (*RAREndpoint, string) {
 	}
 	signer, err := NewEphemeralRARSigner("https://opentdf.local", time.Hour)
 	require.NoError(t, err)
+	cwtSigner, err := NewEphemeralRARCWTSigner("https://opentdf.local", time.Hour)
+	require.NoError(t, err)
 
 	endpoint := &RAREndpoint{
-		pdp:      svc,
-		signer:   signer,
-		verifier: &stubVerifier{expectedToken: "subject-token", subject: "user-1"},
+		pdp:       svc,
+		signer:    signer,
+		cwtSigner: cwtSigner,
+		verifier:  &stubVerifier{expectedToken: "subject-token", subject: "user-1"},
 	}
 	return endpoint, "subject-token"
 }
@@ -263,6 +266,7 @@ func TestRAREndpoint_MaterializesFullEntitlementsByDefault(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeJWT)
 	form.Set("audience", "kas.example")
 	// Note: no authorization_details — we expect EVERYTHING.
 
@@ -399,6 +403,7 @@ func TestRAREndpoint_RejectsBadSubjectToken(t *testing.T) {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", "wrong-token")
 	form.Set("subject_token_type", tokenTypeIDToken)
+	form.Set("requested_token_type", tokenTypeJWT)
 
 	resp, err := http.Post(srv.URL+rarTokenPath, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	require.NoError(t, err)
@@ -446,6 +451,11 @@ func baseForm(subjectToken string) url.Values {
 	form.Set("grant_type", grantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
 	form.Set("subject_token_type", tokenTypeIDToken)
+	// Existing tests in this file assert on the JSON envelope shape. The
+	// platform default is now CWT (raw CBOR body); opt back into JWT here
+	// so each helper test stays focused on its specific concern instead of
+	// re-asserting the format choice.
+	form.Set("requested_token_type", tokenTypeJWT)
 	return form
 }
 


### PR DESCRIPTION
## Summary

Completes the "CWT throughout" story started in #13. The platform now emits **RFC 8392 CWTs (COSE_Sign1 / ES256)** as the default response from the RFC 8693 token-exchange endpoint, with the JWT path opt-in via `requested_token_type=urn:ietf:params:oauth:token-type:jwt`.

Why: callers (PEPs, IdPs like authnz-rs) prefer a single token format end-to-end. The subject-side already accepts CWTs after #13; this PR closes the loop on the response side.

## Wire shape

```
HTTP/1.1 200 OK
Content-Type: application/cwt+cbor
Cache-Control: no-store

<raw bytes = RFC 8392 CWT (tag #61) → COSE_Sign1 → ES256>
```

CWT payload (CBOR map):

| Label | Claim | Value |
|---|---|---|
| `1` | `iss` | configured issuer |
| `2` | `sub` | entity subject |
| `3` | `aud` | requested audience (omitted if absent) |
| `4` | `exp` | unix seconds |
| `5` | `nbf` | unix seconds |
| `6` | `iat` | unix seconds |
| `7` | `cti` | 16-byte UUID |
| `"authorization_details"` | RFC 9396 grant array | text label, JSON-style maps with `type`/`actions`/`locations`/`obligations` |

Standard claims use RFC 8392 integer labels; `authorization_details` uses a text label with the JSON shape so existing `local.Grant` consumers read the same fields.

## Key publication

The signer's public key is published at a new endpoint:

```
GET /v2/authorization/cose-keys
Content-Type: application/cose-key-set+cbor
```

— same shape authnz-rs serves at `/.well-known/cose-keys`, so a PEP that already has a COSE verifier (e.g. for the subject-side CWT) reuses it unchanged.

## ⚠️ Breaking change

`requested_token_type` default flips from JWT to CWT. Clients depending on the JSON envelope shape without setting `requested_token_type` will see a CBOR body. Mitigation: add `requested_token_type=urn:ietf:params:oauth:token-type:jwt` to existing request forms.

## Files

| File | Change |
|---|---|
| `service/authorization/v2/rar_cwt_signer.go` (new) | `RARCWTSigner`: ephemeral ES256 keypair, `Issue(...)`, `COSEKeySet()` |
| `service/authorization/v2/rar.go` | format dispatch on `requested_token_type`; new `/v2/authorization/cose-keys` handler |
| `service/authorization/v2/authorization.go` | parallel CWT-signer construction in `buildRARHandler` |
| `service/authorization/v2/rar_cwt_response_test.go` (new) | 6 integration tests |
| `service/authorization/v2/rar_test.go`, `rar_cwt_test.go` | existing tests opt into JWT explicitly so JSON-envelope assertions still hold |

## Test plan

- [x] `TestRAREndpoint_CWTResponse_IsDefault` — no `requested_token_type` → CBOR body, valid CWT, claims present
- [x] `TestRAREndpoint_CWTResponse_VerifiesAgainstPublishedCOSEKeySet` — full round-trip: response signature verifies against published key
- [x] `TestRAREndpoint_CWTResponse_DisabledWhenSignerMissing` — graceful 400 if CWT signer didn't build
- [x] `TestRAREndpoint_COSEKeysEndpoint` — `/v2/authorization/cose-keys` returns CBOR
- [x] `TestRAREndpoint_JWTResponse_OptIn` — `requested_token_type=jwt` still works
- [x] `TestRAREndpoint_UnknownRequestedTokenTypeRejected` — bogus URN → 400
- [x] All existing 13 rar / rar_cwt tests pass (with the JWT opt-in)
- [x] `go build ./...`, `golangci-lint` clean on changed files
- [ ] End-to-end with a Rust PEP — covered separately in `opentdf-rs` PR #78 (`pep_check.rs` update)

## Out of scope

- Configurable signing-key persistence (still ephemeral per process; restart rotates).
- Multi-key rotation in the published COSE Key Set.
- Removing the JWT path entirely (kept for compatibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)