### PR TITLE
fix(config): make opentdf-core-no-db.yaml actually run without Keycloak

### DIFF
--- a/opentdf-core-no-db.yaml
+++ b/opentdf-core-no-db.yaml
@@ -17,8 +17,11 @@ sdk_config:
   entityresolution:
     endpoint: http://localhost:8181
     plaintext: true
-  client_id: opentdf
-  client_secret: secret
+  # Intentionally no client_id/client_secret: providing them triggers OIDC
+  # discovery against server.auth.issuer at startup (see start.go), which
+  # would force a Keycloak dependency even though server.auth.enabled is
+  # false. Outbound SDK calls in this mode (ERS over plaintext) need no
+  # bearer token, and inbound auth is disabled below.
 
 logger:
   level: info


### PR DESCRIPTION
### Proposed Changes

* Remove `sdk_config.client_id` / `client_secret` from `opentdf-core-no-db.yaml`. The file's purpose is to ship a runtime that needs neither Postgres nor Keycloak, but with those fields set, `pkg/server/start.go` unconditionally calls `auth.DiscoverOIDCConfiguration` against `server.auth.issuer` at startup — so the process died trying to dial Keycloak even with `server.auth.enabled: false`.
* Replace the credentials with an in-file comment explaining the constraint so future readers don't re-add them.

No code changes; this is config-only.

### Checklist

- [x] I have added or updated unit tests *(not applicable — config file only)*
- [x] I have added or updated integration tests (if appropriate) *(not applicable — config file only)*
- [x] I have added or updated documentation *(in-file comment in the YAML)*

### Testing Instructions

```bash
# Before this change, the following used to fail with:
#   Error: could not retrieve oidc configuration: ... connect: connection refused
go build -o opentdf ./service
./opentdf start --config-file ./opentdf-core-no-db.yaml &
curl -s http://localhost:8383/healthz
# → {"status":"SERVING"}
```

Service comes up with `database.required=false` across the board; no outbound OIDC call is made.