### PR TITLE
feat(ers): add Patreon entity resolution provider and policy snapshot

### DIFF
--- a/docs/patreon-authnz-contract.md
+++ b/docs/patreon-authnz-contract.md
@@ -1,0 +1,245 @@
+# Patreon Entitlement Source — `authnz-rs` ↔ opentdf-platform Contract
+
+Status: **proposal**, target implementation `arkavo-org/authnz-rs`.
+
+This document defines the boundary between `authnz-rs` (Arkavo's identity
+gateway) and the opentdf-platform Patreon Entity Resolution Service (ERS).
+It exists so the Rust-side implementation can move forward without the Go
+ERS having to know how OAuth, credential storage, or refresh are handled.
+
+The current opentdf-platform branch (`claude/attribute-authority-tagging-3gTrI`)
+ships:
+
+- `examples/config/policy.patreon.yaml` — namespace, attributes, and subject
+  mappings that consume the claim shape defined below.
+- `service/entityresolution/patreon/v2/` — a single-creator ERS mode that
+  reads a static creator token from config. **It will be refactored** to
+  call `authnz-rs` over RPC instead, once the contract below is implemented.
+
+## Architectural split
+
+| Concern                                                | Owner            |
+|--------------------------------------------------------|------------------|
+| Patreon OAuth code exchange and CSRF state             | `authnz-rs`      |
+| Encrypted refresh + access token storage (KMS-backed)  | `authnz-rs`      |
+| Per-creator token refresh worker (lazy + scheduled)    | `authnz-rs`      |
+| ConnectCreator / ListConnections / RevokeConnection    | `authnz-rs`      |
+| Patreon v2 API client (member search, identity)        | `authnz-rs`      |
+| `patreon.arkavo.com` namespace + attributes            | opentdf-platform |
+| Subject mappings keyed off `.patreon.connections[].*`  | opentdf-platform |
+| ERS mode emitting the claim block from RPC results     | opentdf-platform |
+
+Credentials never enter opentdf-platform. The ERS holds only resolved
+membership data, transiently, for the duration of one
+`ResolveEntities` / `CreateEntityChainsFromTokens` call.
+
+## The one RPC the ERS needs
+
+```proto
+service PatreonEntitlements {
+  // ResolveFanMemberships returns this fan's membership state across every
+  // connected creator. The ERS calls it once per inbound entity-resolution
+  // request; latency budget is < 200ms p99 so authnz-rs must cache
+  // aggressively (per-creator memberships have a natural TTL since the
+  // Patreon webhook lifecycle is creator-scoped).
+  rpc ResolveFanMemberships(ResolveFanMembershipsRequest)
+      returns (ResolveFanMembershipsResponse);
+}
+
+message ResolveFanMembershipsRequest {
+  // Exactly one of these identifies the fan. The ERS supplies whatever the
+  // inbound entity carried.
+  oneof identifier {
+    string patreon_user_id = 1;
+    string email           = 2;
+    // Forwarded backer OAuth token (when the JWT carried one) — authnz-rs
+    // uses /identity directly instead of campaign member search.
+    string user_access_token = 3;
+  }
+
+  // Optional - restrict to a subset of connected creators. Empty = all.
+  repeated string creator_ids = 4;
+}
+
+message ResolveFanMembershipsResponse {
+  repeated Membership connections = 1;
+}
+
+message Membership {
+  string   creator_id        = 1;  // Arkavo's creator id
+  string   campaign_id       = 2;
+  string   patreon_user_id   = 3;
+  string   email             = 4;
+  string   full_name         = 5;
+  string   status            = 6;  // active | declined | former
+  string   tier_slug         = 7;  // free | <slugified tier title>
+  uint32   tier_amount_cents = 8;
+  repeated string benefits   = 9;  // slugified
+  google.protobuf.Timestamp pledge_start    = 10;
+  google.protobuf.Timestamp last_charge_at  = 11;
+}
+```
+
+The claim shape the ERS emits onto subject entities is a direct projection
+of `ResolveFanMembershipsResponse.connections` into a structpb under the
+key `patreon.connections`:
+
+```jsonc
+{
+  "patreon": {
+    "connections": [
+      {
+        "creator_id": "alice", "campaign_id": "12345",
+        "tier_slug": "patron", "status": "active",
+        "benefits": ["early-access", "discord"]
+      },
+      {
+        "creator_id": "bob", "campaign_id": "67890",
+        "tier_slug": "supporter", "status": "active",
+        "benefits": ["early-access"]
+      }
+    ]
+  }
+}
+```
+
+Subject mappings in `policy.patreon.yaml` then key off selectors like
+`.patreon.connections[].creator_id` and `.patreon.connections[].tier_slug`.
+
+### Required `Membership` value invariants
+
+| Field        | Invariant                                                 |
+|--------------|-----------------------------------------------------------|
+| `status`     | Lowercased: `active`, `declined`, or `former`. Maps from Patreon's `patron_status` (`active_patron` → `active`, etc.). |
+| `tier_slug`  | Lowercased, kebab-cased title of the *highest-amount* currently entitled tier. `"free"` when no tier is held. |
+| `benefits`   | Lowercased, kebab-cased benefit titles, deduplicated, sorted. |
+| `creator_id` | Stable Arkavo creator id (NOT Patreon's). Used as the FQN segment for the `campaign` attribute value. |
+
+These invariants match what the ERS already produces; the Rust side must
+preserve them so the existing subject mappings keep working.
+
+## Service-to-service authentication
+
+The ERS calls `authnz-rs` from inside the cluster. Three viable options:
+
+1. **mTLS** with a private CA — preferred for production. authnz-rs verifies
+   the ERS's client cert SAN.
+2. **OIDC service token** — opentdf-platform's existing AccessTokenVerifier
+   issues a service-scoped token; authnz-rs validates it. Matches how the
+   rest of the platform authenticates internal calls.
+3. **Shared static bearer** — only acceptable for dev. Pass via
+   `PATREON_AUTHNZ_BEARER` env var.
+
+The ERS-side config (when this lands) will look like:
+
+```yaml
+services:
+  entityresolution:
+    mode: patreon
+    patreon:
+      authnz_url: https://authnz.arkavo.internal
+      auth:
+        mode: mtls              # or "service_token" | "bearer"
+        client_cert: /etc/tls/ers.crt
+        client_key:  /etc/tls/ers.key
+        ca:          /etc/tls/ca.crt
+      # Optional: synthesize a "free" membership when authnz-rs returns
+      # an empty list, so non-backers still flow through subject mappings.
+      infer_unknown_as_free: true
+      # Timeout for the resolve RPC. ERS treats timeouts as
+      # ErrPatreonUnavailable (not NotFound) so KAS does not deny on a
+      # transient outage.
+      timeout: 750ms
+```
+
+## Connect / Admin surface on authnz-rs
+
+Independent of the ERS contract, `authnz-rs` must expose the operator API
+for creators. Suggested shape (REST or RPC, authnz-rs's choice):
+
+| Method | Path / RPC                                  | Purpose                                                   |
+|--------|---------------------------------------------|-----------------------------------------------------------|
+| `GET`  | `/v1/patreon/oauth/start?creator_id=…`      | Redirect creator to Patreon's authorize endpoint.         |
+| `GET`  | `/v1/patreon/oauth/callback`                | Code exchange + identity lookup; persists the connection. |
+| `POST` | `/v1/patreon/connections`                   | Admin path: `{creator_id, refresh_token}` — for creators who completed OAuth out-of-band or for backfill. |
+| `GET`  | `/v1/patreon/connections`                   | Inventory (no token material; metadata only).             |
+| `DEL`  | `/v1/patreon/connections/{creator_id}`      | Revoke at Patreon, then mark `revoked_at`.                |
+
+CSRF: a `state` nonce keyed to `creator_id` with a short TTL, stored
+server-side. Required Patreon scopes: `identity`, `identity[email]`,
+`campaigns`, `campaigns.members`, `campaigns.members[email]`. Webhook
+ingest (`members:pledge:create|update|delete`) is the path that keeps
+authnz-rs's cache fresh between RPC calls.
+
+## Suggested storage shape (reference, not required)
+
+These columns are what the discarded Go scaffolding modelled; the Rust
+side is free to evolve them. Recorded here so the schema choices aren't
+lost:
+
+```sql
+CREATE TABLE patreon_creator_connections (
+    id                       UUID PRIMARY KEY,
+    creator_id               TEXT UNIQUE NOT NULL,
+    patreon_user_id          TEXT NOT NULL,
+    campaign_id              TEXT NOT NULL,
+    scopes                   TEXT[] NOT NULL DEFAULT '{}',
+    access_token_ciphertext  BYTEA NOT NULL,
+    access_token_expires_at  TIMESTAMPTZ NOT NULL,
+    refresh_token_ciphertext BYTEA,
+    key_id                   TEXT NOT NULL, -- KMS key version stamp
+    connected_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_refreshed_at        TIMESTAMPTZ,
+    revoked_at               TIMESTAMPTZ,
+    metadata                 JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- Partial indexes that matter:
+-- (creator_id) WHERE revoked_at IS NULL  -- ERS lookups
+-- (access_token_expires_at) WHERE revoked_at IS NULL  -- refresh worker
+```
+
+Refresh tokens are AES-256-GCM-encrypted under a KMS-managed key. `key_id`
+identifies the key version so rotation is lazy.
+
+## Migration plan (Go-side)
+
+When `authnz-rs` is ready:
+
+1. Add a `patreon.authnz_url` and auth block to the platform config.
+2. Replace `service/entityresolution/patreon/v2/client.go`'s direct Patreon
+   API code with an `authnz-rs` RPC client (same `MembershipAPI` interface
+   the ERS already depends on).
+3. Refactor `ResolveEntities` / `CreateEntityChainsFromTokens` to call
+   `ResolveFanMemberships` once per request and emit
+   `.patreon.connections[]` (multi-creator) instead of the current
+   single-membership `.patreon.*` shape.
+4. Update `policy.patreon.yaml` subject mappings:
+   - `.patreon.tier_slug` → `.patreon.connections[].tier_slug` (subject
+     mappings already use the `IN` operator over arrays).
+   - Add per-creator `campaign` value mappings keyed off
+     `.patreon.connections[].creator_id`.
+5. Delete the static `creator_access_token` / `campaign_ids` config
+   fields from the ERS — they become a property of each connection in
+   authnz-rs.
+
+The policy YAML in this branch already uses array-flavored selectors
+(`.patreon.benefits[]`, `.patreon.campaign_ids[]`), so step 4 is a
+search-and-replace, not a redesign.
+
+## Open questions
+
+- Where does the **Arkavo creator id** live as a stable identifier? authnz-rs
+  needs a non-Patreon canonical id to use in `creator_id`. If creators
+  live in opentdf's user store, the OAuth start endpoint takes their id
+  from the caller's session; otherwise authnz-rs owns its own creator
+  registry.
+- **Cache invalidation across services**. Patreon webhooks land at
+  authnz-rs; the ERS does not subscribe. A `last_modified` field on
+  `Membership` plus a short opentdf-side cache (e.g. 30s) is probably
+  sufficient — confirm before we wire caching.
+- **Scope for future sources** (Stripe, Substack). If they end up here
+  too, the RPC should generalize: `ResolveFanEntitlements` returning
+  source-tagged blocks (`patreon.connections[]`, `stripe.subscriptions[]`,
+  …). Doing it Patreon-only now is fine; the proto leaves room.

--- a/examples/config/policy.patreon.yaml
+++ b/examples/config/policy.patreon.yaml
@@ -1,0 +1,291 @@
+# Patreon-backed policy snapshot.
+#
+# Defines two attribute axes for data tagging plus three Patreon-sourced
+# subject attributes (tier, campaign, status) with subject mappings keyed off
+# the claim shape produced by the Patreon entity resolution provider
+# (service/entityresolution/patreon).
+#
+# Reference this file from opentdf.yaml as:
+#
+#   services:
+#     authorization:
+#       policy_file: ./examples/config/policy.patreon.yaml
+#
+# Run the platform without the policy CRUD service to skip Postgres entirely:
+#
+#   mode: core,-policy
+
+namespaces:
+  - name: patreon.arkavo.com
+
+key_access_servers:
+  - id: kas-arkavo
+    uri: https://kas.arkavo.com
+
+attributes:
+  # ---- Data-tagging attributes (assigned to TDFs at encryption time) ----
+  - namespace: patreon.arkavo.com
+    name: classification
+    rule: hierarchy
+    grants:
+      - id: kas-arkavo
+    values:
+      - value: public
+      - value: member
+      - value: paid
+      - value: vip
+
+  - namespace: patreon.arkavo.com
+    name: content-type
+    rule: anyOf
+    values:
+      - value: text
+      - value: image
+      - value: video
+      - value: audio
+
+  - namespace: patreon.arkavo.com
+    name: entitlement
+    rule: allOf
+    values:
+      - value: exclusive-content
+      - value: early-access
+      - value: behind-the-scenes
+      - value: live-stream
+      - value: discord
+
+  # ---- Patreon-sourced subject attributes ----
+  # tier mirrors Patreon's pledge tiers as a hierarchy so encrypting against
+  # `supporter` admits anyone at supporter, patron, or vip.
+  - namespace: patreon.arkavo.com
+    name: tier
+    rule: hierarchy
+    grants:
+      - id: kas-arkavo
+    values:
+      - value: vip
+      - value: patron
+      - value: supporter
+      - value: free
+
+  # campaign is flat (anyOf) because a backer may support multiple unrelated
+  # creators; each campaign id becomes a distinct attribute value.
+  - namespace: patreon.arkavo.com
+    name: campaign
+    rule: anyOf
+    values:
+      - value: arkavo
+
+  - namespace: patreon.arkavo.com
+    name: status
+    rule: anyOf
+    values:
+      - value: active
+      - value: declined
+      - value: former
+
+subject_mappings:
+  # tier mappings: each tier value matches when the Patreon ERS surfaces the
+  # corresponding tier slug in the patreon.tier_slug claim.
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/tier/value/vip
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.tier_slug
+                  operator: IN
+                  subject_external_values:
+                    - vip
+                - subject_external_selector_value: .patreon.status
+                  operator: IN
+                  subject_external_values:
+                    - active
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/tier/value/patron
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.tier_slug
+                  operator: IN
+                  subject_external_values:
+                    - patron
+                - subject_external_selector_value: .patreon.status
+                  operator: IN
+                  subject_external_values:
+                    - active
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/tier/value/supporter
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.tier_slug
+                  operator: IN
+                  subject_external_values:
+                    - supporter
+                - subject_external_selector_value: .patreon.status
+                  operator: IN
+                  subject_external_values:
+                    - active
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/tier/value/free
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.tier_slug
+                  operator: IN
+                  subject_external_values:
+                    - free
+                    - ""
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  # campaign: subject is entitled to a campaign value when that campaign id
+  # appears in the resolved patreon.campaign_ids array claim.
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/campaign/value/arkavo
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.campaign_ids[]
+                  operator: IN
+                  subject_external_values:
+                    - arkavo
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  # status: surface the Patreon membership lifecycle so policies can revoke
+  # access when payments fail.
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/status/value/active
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.status
+                  operator: IN
+                  subject_external_values:
+                    - active
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/status/value/declined
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.status
+                  operator: IN
+                  subject_external_values:
+                    - declined
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/status/value/former
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.status
+                  operator: IN
+                  subject_external_values:
+                    - former
+
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  # Entitlement mappings derived from Patreon benefits. The Patreon ERS
+  # surfaces benefit slugs in patreon.benefits[]; the allOf rule means data
+  # tagged with several entitlements requires the subject to hold all of them.
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/entitlement/value/exclusive-content
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.benefits[]
+                  operator: IN
+                  subject_external_values:
+                    - exclusive-content
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/entitlement/value/early-access
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.benefits[]
+                  operator: IN
+                  subject_external_values:
+                    - early-access
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/entitlement/value/behind-the-scenes
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.benefits[]
+                  operator: IN
+                  subject_external_values:
+                    - behind-the-scenes
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/entitlement/value/live-stream
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.benefits[]
+                  operator: IN
+                  subject_external_values:
+                    - live-stream
+    actions:
+      - name: read
+        standard: TRANSMIT
+
+  - attribute_value_fqn: https://patreon.arkavo.com/attr/entitlement/value/discord
+    inline_condition_set:
+      subject_sets:
+        - condition_groups:
+            - boolean_operator: AND
+              conditions:
+                - subject_external_selector_value: .patreon.benefits[]
+                  operator: IN
+                  subject_external_values:
+                    - discord
+    actions:
+      - name: read
+        standard: TRANSMIT

--- a/examples/config/policy.patreon.yaml
+++ b/examples/config/policy.patreon.yaml
@@ -69,7 +69,9 @@ attributes:
       - value: free
 
   # campaign is flat (anyOf) because a backer may support multiple unrelated
-  # creators; each campaign id becomes a distinct attribute value.
+  # creators. The value slug is a human-readable creator name; the subject
+  # mapping below pins it to the numeric Patreon campaign id the resolver
+  # emits in .patreon.campaign_ids.
   - namespace: patreon.arkavo.com
     name: campaign
     rule: anyOf
@@ -156,8 +158,11 @@ subject_mappings:
       - name: read
         standard: TRANSMIT
 
-  # campaign: subject is entitled to a campaign value when that campaign id
-  # appears in the resolved patreon.campaign_ids array claim.
+  # campaign: subject is entitled to a campaign value when that campaign's
+  # numeric Patreon id appears in the resolved patreon.campaign_ids array
+  # claim. The resolver emits numeric ids (e.g. "12345678"), not creator
+  # slugs — replace with your own campaign id (the same one configured under
+  # the ERS campaign_ids list).
   - attribute_value_fqn: https://patreon.arkavo.com/attr/campaign/value/arkavo
     inline_condition_set:
       subject_sets:
@@ -167,7 +172,7 @@ subject_mappings:
                 - subject_external_selector_value: .patreon.campaign_ids[]
                   operator: IN
                   subject_external_values:
-                    - arkavo
+                    - "12345678"
     actions:
       - name: read
         standard: TRANSMIT

--- a/service/entityresolution/patreon/v2/README.md
+++ b/service/entityresolution/patreon/v2/README.md
@@ -1,0 +1,85 @@
+# Patreon Entity Resolution Provider (v2)
+
+A Patreon-backed Entity Resolution Service (ERS) that resolves a subject's
+Patreon membership state and surfaces it as policy claims under the
+`.patreon.*` selector tree. Pairs with
+[`examples/config/policy.patreon.yaml`](../../../../examples/config/policy.patreon.yaml).
+
+## What it does
+
+For each `ResolveEntities` request entry, the provider looks the subject up in
+Patreon (by user id, email, JWT claim, or forwarded user OAuth token) and
+returns a representation that includes:
+
+```jsonc
+{
+  "patreon": {
+    "user_id": "12345",
+    "email": "fan@example.com",
+    "full_name": "Fan One",
+    "status": "active",            // active | declined | former
+    "tier_slug": "patron",         // slugified tier name; "free" if none
+    "tier_amount_cents": 500,
+    "campaign_ids": ["arkavo"],
+    "benefits": ["early-access", "exclusive-content"]
+  }
+}
+```
+
+Subject mappings in `policy.patreon.yaml` key off these fields - e.g.
+`.patreon.tier_slug == "patron"` grants the
+`https://patreon.arkavo.com/attr/tier/value/patron` attribute value.
+
+## Configuration
+
+```yaml
+services:
+  entityresolution:
+    mode: patreon
+    # One of these must be set:
+    creator_access_token: ${PATREON_CREATOR_ACCESS_TOKEN}
+    # ...or for client_credentials refresh:
+    # client_id: ${PATREON_CLIENT_ID}
+    # client_secret: ${PATREON_CLIENT_SECRET}
+
+    # Restrict member lookups to specific campaign ids (leave empty to
+    # auto-list campaigns this token has access to).
+    campaign_ids:
+      - "12345678"
+
+    # Return a synthetic free-tier membership when a subject is not a backer
+    # (instead of returning NotFound). Useful so unauthenticated/non-Patreon
+    # traffic still flows through the subject mapping engine.
+    infer_unknown_as_free: true
+
+    # JWT claim overrides (defaults shown).
+    jwt:
+      patreon_user_id_claim: patreon_user_id
+      patreon_access_token_claim: patreon_access_token
+      username_claim: preferred_username
+      client_id_claim: azp
+```
+
+## Resolution strategy
+
+`ResolveEntities` chooses a lookup path per entity type:
+
+| Entity type      | Lookup                                                |
+|------------------|-------------------------------------------------------|
+| `UserName`       | Patreon user id (campaign member search)              |
+| `EmailAddress`   | Patreon email (campaign member search)                |
+| `ClientId`       | Treated as Patreon user id                            |
+| `Claims` (JWT)   | In priority: `patreon_access_token` -> `patreon_user_id` -> `email` -> `preferred_username` |
+
+`CreateEntityChainsFromTokens` parses each JWT (signature-unverified, like the
+other ERS modes), emits an `ENVIRONMENT` entity for the `azp` client id, and
+a `SUBJECT` entity whose claims are the `patreon` block above.
+
+## Testing
+
+```bash
+cd service && go test ./entityresolution/patreon/...
+```
+
+Tests use an in-memory `MembershipAPI` stub plus an `httptest` server to
+exercise pagination and JSON:API parsing. No outbound Patreon calls are made.

--- a/service/entityresolution/patreon/v2/client.go
+++ b/service/entityresolution/patreon/v2/client.go
@@ -1,0 +1,635 @@
+package patreon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultAPIBase     = "https://www.patreon.com/api/oauth2/v2"
+	defaultTokenURL    = "https://www.patreon.com/api/oauth2/token" //nolint:gosec // URL, not a credential
+	identityResource   = "/identity"
+	campaignsResource  = "/campaigns"
+	defaultHTTPTimeout = 15 * time.Second
+	httpStatusOKBucket = 2 // numerator/100 for 2xx responses
+)
+
+var (
+	ErrPatreonUnavailable = errors.New("patreon api unavailable")
+	ErrMemberNotFound     = errors.New("patreon member not found")
+)
+
+// Membership is the subject-claim view of Patreon state surfaced to the
+// policy engine. Field names back the .patreon.* selectors in subject
+// mappings (see examples/config/policy.patreon.yaml).
+type Membership struct {
+	UserID       string   `json:"user_id"`
+	Email        string   `json:"email"`
+	FullName     string   `json:"full_name"`
+	Status       string   `json:"status"`
+	TierSlug     string   `json:"tier_slug"`
+	TierAmount   int      `json:"tier_amount_cents"`
+	CampaignIDs  []string `json:"campaign_ids"`
+	Benefits     []string `json:"benefits"`
+	PledgeStart  string   `json:"pledge_start,omitempty"`
+	LastChargeAt string   `json:"last_charge_at,omitempty"`
+}
+
+// Client is a minimal Patreon v2 API client scoped to what the ERS needs:
+// resolve a backer's membership state from an identifier (user id, email, or
+// the backer's own OAuth access token).
+type Client struct {
+	httpClient   *http.Client
+	apiBase      string
+	tokenURL     string
+	clientID     string
+	clientSecret string
+	creatorToken string
+	campaignIDs  []string
+
+	mu          sync.Mutex
+	cachedToken string
+	tokenExpiry time.Time
+}
+
+// ClientOptions configures the Patreon client. Either CreatorAccessToken
+// (long-lived creator token used to list campaign members) or the
+// ClientID/ClientSecret pair (for refreshing the creator token) must be set.
+type ClientOptions struct {
+	APIBase            string
+	TokenURL           string
+	HTTPClient         *http.Client
+	ClientID           string
+	ClientSecret       string
+	CreatorAccessToken string
+	CampaignIDs        []string
+}
+
+func NewClient(opts ClientOptions) *Client {
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	apiBase := opts.APIBase
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+	tokenURL := opts.TokenURL
+	if tokenURL == "" {
+		tokenURL = defaultTokenURL
+	}
+	return &Client{
+		httpClient:   httpClient,
+		apiBase:      strings.TrimRight(apiBase, "/"),
+		tokenURL:     tokenURL,
+		clientID:     opts.ClientID,
+		clientSecret: opts.ClientSecret,
+		creatorToken: opts.CreatorAccessToken,
+		campaignIDs:  opts.CampaignIDs,
+	}
+}
+
+// CampaignIDs returns the configured campaign ids this client searches.
+func (c *Client) CampaignIDs() []string {
+	return c.campaignIDs
+}
+
+// ResolveByUserID looks up a backer by their Patreon user id across every
+// configured campaign.
+func (c *Client) ResolveByUserID(ctx context.Context, userID string) (*Membership, error) {
+	return c.findMember(ctx, func(m *memberRow) bool {
+		return m.userID == userID
+	})
+}
+
+// ResolveByEmail looks up a backer by email (case-insensitive) across every
+// configured campaign.
+func (c *Client) ResolveByEmail(ctx context.Context, email string) (*Membership, error) {
+	wanted := strings.ToLower(strings.TrimSpace(email))
+	if wanted == "" {
+		return nil, ErrMemberNotFound
+	}
+	return c.findMember(ctx, func(m *memberRow) bool {
+		return strings.EqualFold(m.email, wanted)
+	})
+}
+
+// ResolveSelf calls the identity endpoint using a backer's OAuth access
+// token to fetch their own membership state.
+func (c *Client) ResolveSelf(ctx context.Context, userAccessToken string) (*Membership, error) {
+	if userAccessToken == "" {
+		return nil, ErrMemberNotFound
+	}
+	q := url.Values{}
+	q.Set("include", "memberships,memberships.currently_entitled_tiers,memberships.campaign,memberships.currently_entitled_tiers.benefits")
+	q.Set("fields[user]", "email,full_name")
+	q.Set("fields[member]", "patron_status,currently_entitled_amount_cents,last_charge_date,pledge_relationship_start")
+	q.Set("fields[tier]", "title,amount_cents")
+	q.Set("fields[benefit]", "title")
+	u := c.apiBase + identityResource + "?" + q.Encode()
+
+	raw := json.RawMessage(nil)
+	if err := c.doJSON(ctx, http.MethodGet, u, userAccessToken, &raw); err != nil {
+		return nil, err
+	}
+	return parseIdentity(raw)
+}
+
+func (c *Client) findMember(ctx context.Context, match func(*memberRow) bool) (*Membership, error) {
+	token, err := c.creatorAccessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	campaigns := c.campaignIDs
+	if len(campaigns) == 0 {
+		ids, err := c.listCampaigns(ctx, token)
+		if err != nil {
+			return nil, err
+		}
+		campaigns = ids
+	}
+
+	for _, campaignID := range campaigns {
+		member, err := c.searchCampaignMembers(ctx, token, campaignID, match)
+		if err != nil {
+			return nil, err
+		}
+		if member != nil {
+			return member, nil
+		}
+	}
+	return nil, ErrMemberNotFound
+}
+
+func (c *Client) searchCampaignMembers(ctx context.Context, token, campaignID string, match func(*memberRow) bool) (*Membership, error) {
+	cursor := ""
+	for {
+		q := url.Values{}
+		q.Set("include", "user,currently_entitled_tiers,currently_entitled_tiers.benefits")
+		q.Set("fields[member]", "email,full_name,patron_status,currently_entitled_amount_cents,last_charge_date,pledge_relationship_start")
+		q.Set("fields[user]", "email,full_name")
+		q.Set("fields[tier]", "title,amount_cents")
+		q.Set("fields[benefit]", "title")
+		q.Set("page[count]", "100")
+		if cursor != "" {
+			q.Set("page[cursor]", cursor)
+		}
+		u := fmt.Sprintf("%s/campaigns/%s/members?%s", c.apiBase, url.PathEscape(campaignID), q.Encode())
+
+		raw := json.RawMessage(nil)
+		if err := c.doJSON(ctx, http.MethodGet, u, token, &raw); err != nil {
+			return nil, err
+		}
+		page, err := parseMembersPage(raw)
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range page.members {
+			if match(&row) {
+				return row.toMembership(campaignID), nil
+			}
+		}
+		if page.nextCursor == "" {
+			return nil, nil //nolint:nilnil // sentinel for "kept searching, didn't find"
+		}
+		cursor = page.nextCursor
+	}
+}
+
+func (c *Client) listCampaigns(ctx context.Context, token string) ([]string, error) {
+	u := c.apiBase + campaignsResource
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, u, token, &resp); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		ids = append(ids, d.ID)
+	}
+	return ids, nil
+}
+
+// creatorAccessToken returns a usable access token, refreshing via the
+// client_credentials grant when a client id/secret are configured.
+func (c *Client) creatorAccessToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry.Add(-1*time.Minute)) {
+		return c.cachedToken, nil
+	}
+	if c.creatorToken != "" {
+		return c.creatorToken, nil
+	}
+	if c.clientID == "" || c.clientSecret == "" {
+		return "", fmt.Errorf("%w: no creator token and no client credentials configured", ErrPatreonUnavailable)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", c.clientID)
+	form.Set("client_secret", c.clientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrPatreonUnavailable, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != httpStatusOKBucket {
+		return "", fmt.Errorf("%w: token endpoint returned %s: %s", ErrPatreonUnavailable, resp.Status, string(body))
+	}
+	var tokResp struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokResp); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrPatreonUnavailable, err)
+	}
+	c.cachedToken = tokResp.AccessToken
+	c.tokenExpiry = time.Now().Add(time.Duration(tokResp.ExpiresIn) * time.Second)
+	return c.cachedToken, nil
+}
+
+func (c *Client) doJSON(ctx context.Context, method, target, bearer string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, method, target, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrPatreonUnavailable, err)
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("%w: read body: %w", ErrPatreonUnavailable, readErr)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrMemberNotFound
+	}
+	if resp.StatusCode/100 != httpStatusOKBucket {
+		return fmt.Errorf("%w: %s: %s", ErrPatreonUnavailable, resp.Status, string(body))
+	}
+	return json.Unmarshal(body, out)
+}
+
+// ---- JSON:API response parsing ----
+//
+// Patreon's API is JSON:API: a `data` array of resources and an `included`
+// array of related resources. Resources reference each other via
+// `relationships[name].data` ({id,type} pointers). We parse generically
+// because the relationships span types (member -> user, member -> tier,
+// tier -> benefit).
+
+type memberRow struct {
+	id           string
+	userID       string
+	email        string
+	fullName     string
+	status       string
+	tierSlug     string
+	tierAmount   int
+	benefits     []string
+	pledgeStart  string
+	lastChargeAt string
+}
+
+func (m *memberRow) toMembership(campaignID string) *Membership {
+	out := &Membership{
+		UserID:       m.userID,
+		Email:        m.email,
+		FullName:     m.fullName,
+		Status:       m.status,
+		TierSlug:     m.tierSlug,
+		TierAmount:   m.tierAmount,
+		Benefits:     m.benefits,
+		PledgeStart:  m.pledgeStart,
+		LastChargeAt: m.lastChargeAt,
+	}
+	if campaignID != "" {
+		out.CampaignIDs = []string{campaignID}
+	}
+	if out.TierSlug == "" {
+		out.TierSlug = "free"
+	}
+	out.Status = normalizeStatus(out.Status)
+	return out
+}
+
+type membersPage struct {
+	members    []memberRow
+	nextCursor string
+}
+
+type rawResource struct {
+	ID            string                     `json:"id"`
+	Type          string                     `json:"type"`
+	Attributes    map[string]json.RawMessage `json:"attributes"`
+	Relationships map[string]struct {
+		// JSON:API allows data to be either a single object or an array;
+		// we always normalize to a slice below.
+		Data json.RawMessage `json:"data"`
+	} `json:"relationships"`
+}
+
+type resourceIndex struct {
+	users    map[string]rawResource
+	tiers    map[string]rawResource
+	benefits map[string]rawResource
+	members  map[string]rawResource
+}
+
+func indexResources(included []rawResource) *resourceIndex {
+	idx := &resourceIndex{
+		users:    map[string]rawResource{},
+		tiers:    map[string]rawResource{},
+		benefits: map[string]rawResource{},
+		members:  map[string]rawResource{},
+	}
+	for _, r := range included {
+		switch r.Type {
+		case "user":
+			idx.users[r.ID] = r
+		case "tier":
+			idx.tiers[r.ID] = r
+		case "benefit":
+			idx.benefits[r.ID] = r
+		case "member":
+			idx.members[r.ID] = r
+		}
+	}
+	return idx
+}
+
+// relRefs returns the {id,type} pointers under relationships[name].
+func relRefs(r rawResource, name string) []struct{ ID, Type string } {
+	raw, ok := r.Relationships[name]
+	if !ok || len(raw.Data) == 0 {
+		return nil
+	}
+	// data may be a single object or an array.
+	if raw.Data[0] == '[' {
+		var arr []struct {
+			ID   string `json:"id"`
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(raw.Data, &arr); err != nil {
+			return nil
+		}
+		out := make([]struct{ ID, Type string }, len(arr))
+		for i, a := range arr {
+			out[i] = struct{ ID, Type string }{a.ID, a.Type}
+		}
+		return out
+	}
+	var single struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw.Data, &single); err != nil {
+		return nil
+	}
+	if single.ID == "" {
+		return nil
+	}
+	return []struct{ ID, Type string }{{single.ID, single.Type}}
+}
+
+func attrString(r rawResource, key string) string {
+	raw, ok := r.Attributes[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+func attrInt(r rawResource, key string) int {
+	raw, ok := r.Attributes[key]
+	if !ok {
+		return 0
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0
+	}
+	return n
+}
+
+func hydrateUserFields(row *memberRow, r rawResource, idx *resourceIndex) {
+	refs := relRefs(r, "user")
+	if len(refs) == 0 {
+		return
+	}
+	row.userID = refs[0].ID
+	u, ok := idx.users[refs[0].ID]
+	if !ok {
+		return
+	}
+	if e := attrString(u, "email"); e != "" {
+		row.email = e
+	}
+	if n := attrString(u, "full_name"); n != "" {
+		row.fullName = n
+	}
+}
+
+func memberFromResource(r rawResource, idx *resourceIndex) memberRow {
+	row := memberRow{
+		id:           r.ID,
+		email:        attrString(r, "email"),
+		fullName:     attrString(r, "full_name"),
+		status:       attrString(r, "patron_status"),
+		tierAmount:   attrInt(r, "currently_entitled_amount_cents"),
+		pledgeStart:  attrString(r, "pledge_relationship_start"),
+		lastChargeAt: attrString(r, "last_charge_date"),
+	}
+	hydrateUserFields(&row, r, idx)
+	// tiers + benefits-via-tier
+	tierRefs := relRefs(r, "currently_entitled_tiers")
+	bestAmount := -1
+	benefitSet := map[string]struct{}{}
+	for _, tref := range tierRefs {
+		tier, found := idx.tiers[tref.ID]
+		if !found {
+			continue
+		}
+		amount := attrInt(tier, "amount_cents")
+		if amount > bestAmount {
+			bestAmount = amount
+			row.tierSlug = slugify(attrString(tier, "title"))
+		}
+		for _, bref := range relRefs(tier, "benefits") {
+			b, bfound := idx.benefits[bref.ID]
+			if !bfound {
+				continue
+			}
+			if s := slugify(attrString(b, "title")); s != "" {
+				benefitSet[s] = struct{}{}
+			}
+		}
+	}
+	row.benefits = sortedKeys(benefitSet)
+	return row
+}
+
+func parseMembersPage(raw json.RawMessage) (*membersPage, error) {
+	var resp struct {
+		Data     []rawResource `json:"data"`
+		Included []rawResource `json:"included"`
+		Meta     struct {
+			Pagination struct {
+				Cursors struct {
+					Next string `json:"next"`
+				} `json:"cursors"`
+			} `json:"pagination"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+	idx := indexResources(resp.Included)
+	page := &membersPage{nextCursor: resp.Meta.Pagination.Cursors.Next}
+	for _, d := range resp.Data {
+		page.members = append(page.members, memberFromResource(d, idx))
+	}
+	return page, nil
+}
+
+func parseIdentity(raw json.RawMessage) (*Membership, error) {
+	var resp struct {
+		Data     rawResource   `json:"data"`
+		Included []rawResource `json:"included"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+	idx := indexResources(resp.Included)
+	mem := &Membership{
+		UserID:   resp.Data.ID,
+		Email:    attrString(resp.Data, "email"),
+		FullName: attrString(resp.Data, "full_name"),
+		TierSlug: "free",
+		Status:   normalizeStatus(""),
+	}
+	bestAmount := -1
+	benefitSet := map[string]struct{}{}
+	campaignSet := map[string]struct{}{}
+	for _, mref := range relRefs(resp.Data, "memberships") {
+		mres, ok := idx.members[mref.ID]
+		if !ok {
+			continue
+		}
+		row := memberFromResource(mres, idx)
+		if row.tierAmount > bestAmount {
+			bestAmount = row.tierAmount
+			mem.TierSlug = row.tierSlug
+			mem.TierAmount = row.tierAmount
+		}
+		if row.status != "" {
+			mem.Status = normalizeStatus(row.status)
+		}
+		if row.lastChargeAt != "" {
+			mem.LastChargeAt = row.lastChargeAt
+		}
+		if row.pledgeStart != "" {
+			mem.PledgeStart = row.pledgeStart
+		}
+		for _, b := range row.benefits {
+			benefitSet[b] = struct{}{}
+		}
+		for _, cref := range relRefs(mres, "campaign") {
+			campaignSet[cref.ID] = struct{}{}
+		}
+	}
+	mem.Benefits = sortedKeys(benefitSet)
+	mem.CampaignIDs = sortedKeys(campaignSet)
+	return mem, nil
+}
+
+func normalizeStatus(in string) string {
+	switch strings.ToLower(in) {
+	case "active_patron":
+		return "active"
+	case "declined_patron":
+		return "declined"
+	case "former_patron":
+		return "former"
+	case "":
+		return "former"
+	default:
+		return strings.ToLower(in)
+	}
+}
+
+func slugify(in string) string {
+	in = strings.ToLower(strings.TrimSpace(in))
+	if in == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(in))
+	prevDash := false
+	for _, r := range in {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		case r == '-' || r == '_' || r == ' ':
+			if !prevDash {
+				b.WriteRune('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Deterministic order for stable claims output.
+	sortStrings(out)
+	return out
+}
+
+// sortStrings is a tiny insertion sort to avoid pulling in sort just for
+// this small set; member benefit lists are typically <20 entries.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/service/entityresolution/patreon/v2/client.go
+++ b/service/entityresolution/patreon/v2/client.go
@@ -20,6 +20,22 @@ const (
 	campaignsResource  = "/campaigns"
 	defaultHTTPTimeout = 15 * time.Second
 	httpStatusOKBucket = 2 // numerator/100 for 2xx responses
+
+	// tokenExpirySafetyMargin refreshes the cached creator token slightly
+	// before Patreon's stated expiry so in-flight requests don't race it.
+	tokenExpirySafetyMargin = time.Minute
+	// defaultTokenTTL caches a token whose response omits expires_in (or
+	// reports 0) — otherwise it would be treated as immediately stale and
+	// re-fetched on every request.
+	defaultTokenTTL = time.Hour
+)
+
+// Normalized claim values surfaced to the policy engine.
+const (
+	tierFree       = "free"
+	statusActive   = "active"
+	statusDeclined = "declined"
+	statusFormer   = "former"
 )
 
 var (
@@ -55,7 +71,8 @@ type Client struct {
 	creatorToken string
 	campaignIDs  []string
 
-	mu          sync.Mutex
+	mu          sync.Mutex // guards cachedToken/tokenExpiry; never held across I/O
+	refreshMu   sync.Mutex // single-flights token refreshes
 	cachedToken string
 	tokenExpiry time.Time
 }
@@ -160,6 +177,12 @@ func (c *Client) findMember(ctx context.Context, match func(*memberRow) bool) (*
 	for _, campaignID := range campaigns {
 		member, err := c.searchCampaignMembers(ctx, token, campaignID, match)
 		if err != nil {
+			// A 404 from one campaign's member endpoint (invalid, deleted,
+			// or inaccessible to this token) must not abort the search — a
+			// backer may exist only in a later campaign.
+			if errors.Is(err, ErrMemberNotFound) {
+				continue
+			}
 			return nil, err
 		}
 		if member != nil {
@@ -221,20 +244,38 @@ func (c *Client) listCampaigns(ctx context.Context, token string) ([]string, err
 	return ids, nil
 }
 
-// creatorAccessToken returns a usable access token, refreshing via the
-// client_credentials grant when a client id/secret are configured.
-func (c *Client) creatorAccessToken(ctx context.Context) (string, error) {
+// cachedCreatorToken returns the cached client_credentials token if it is
+// still comfortably inside its expiry window.
+func (c *Client) cachedCreatorToken() (string, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry.Add(-tokenExpirySafetyMargin)) {
+		return c.cachedToken, true
+	}
+	return "", false
+}
 
-	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry.Add(-1*time.Minute)) {
-		return c.cachedToken, nil
+// creatorAccessToken returns a usable access token, refreshing via the
+// client_credentials grant when a client id/secret are configured. Refreshes
+// are single-flighted on refreshMu so concurrent callers don't stampede the
+// token endpoint, while c.mu is only ever held for memory operations — never
+// across the HTTP round-trip.
+func (c *Client) creatorAccessToken(ctx context.Context) (string, error) {
+	if tok, ok := c.cachedCreatorToken(); ok {
+		return tok, nil
 	}
 	if c.creatorToken != "" {
 		return c.creatorToken, nil
 	}
 	if c.clientID == "" || c.clientSecret == "" {
 		return "", fmt.Errorf("%w: no creator token and no client credentials configured", ErrPatreonUnavailable)
+	}
+
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	// Another caller may have completed the refresh while we waited.
+	if tok, ok := c.cachedCreatorToken(); ok {
+		return tok, nil
 	}
 
 	form := url.Values{}
@@ -265,9 +306,15 @@ func (c *Client) creatorAccessToken(ctx context.Context) (string, error) {
 	if err := json.Unmarshal(body, &tokResp); err != nil {
 		return "", fmt.Errorf("%w: %w", ErrPatreonUnavailable, err)
 	}
+	ttl := time.Duration(tokResp.ExpiresIn) * time.Second
+	if ttl <= 0 {
+		ttl = defaultTokenTTL
+	}
+	c.mu.Lock()
 	c.cachedToken = tokResp.AccessToken
-	c.tokenExpiry = time.Now().Add(time.Duration(tokResp.ExpiresIn) * time.Second)
-	return c.cachedToken, nil
+	c.tokenExpiry = time.Now().Add(ttl)
+	c.mu.Unlock()
+	return tokResp.AccessToken, nil
 }
 
 func (c *Client) doJSON(ctx context.Context, method, target, bearer string, out interface{}) error {
@@ -333,7 +380,7 @@ func (m *memberRow) toMembership(campaignID string) *Membership {
 		out.CampaignIDs = []string{campaignID}
 	}
 	if out.TierSlug == "" {
-		out.TierSlug = "free"
+		out.TierSlug = tierFree
 	}
 	out.Status = normalizeStatus(out.Status)
 	return out
@@ -535,7 +582,7 @@ func parseIdentity(raw json.RawMessage) (*Membership, error) {
 		UserID:   resp.Data.ID,
 		Email:    attrString(resp.Data, "email"),
 		FullName: attrString(resp.Data, "full_name"),
-		TierSlug: "free",
+		TierSlug: tierFree,
 		Status:   normalizeStatus(""),
 	}
 	bestAmount := -1
@@ -576,13 +623,13 @@ func parseIdentity(raw json.RawMessage) (*Membership, error) {
 func normalizeStatus(in string) string {
 	switch strings.ToLower(in) {
 	case "active_patron":
-		return "active"
+		return statusActive
 	case "declined_patron":
-		return "declined"
+		return statusDeclined
 	case "former_patron":
-		return "former"
+		return statusFormer
 	case "":
-		return "former"
+		return statusFormer
 	default:
 		return strings.ToLower(in)
 	}

--- a/service/entityresolution/patreon/v2/client.go
+++ b/service/entityresolution/patreon/v2/client.go
@@ -71,6 +71,8 @@ type Client struct {
 	creatorToken string
 	campaignIDs  []string
 
+	warn func(ctx context.Context, msg string, args ...any)
+
 	mu          sync.Mutex // guards cachedToken/tokenExpiry; never held across I/O
 	refreshMu   sync.Mutex // single-flights token refreshes
 	cachedToken string
@@ -88,6 +90,10 @@ type ClientOptions struct {
 	ClientSecret       string
 	CreatorAccessToken string
 	CampaignIDs        []string
+	// Warn, when set, receives operator-actionable warnings (e.g. a
+	// configured campaign id returning 404, which is indistinguishable
+	// from an empty campaign at the API level).
+	Warn func(ctx context.Context, msg string, args ...any)
 }
 
 func NewClient(opts ClientOptions) *Client {
@@ -111,6 +117,7 @@ func NewClient(opts ClientOptions) *Client {
 		clientSecret: opts.ClientSecret,
 		creatorToken: opts.CreatorAccessToken,
 		campaignIDs:  opts.CampaignIDs,
+		warn:         opts.Warn,
 	}
 }
 
@@ -160,6 +167,12 @@ func (c *Client) ResolveSelf(ctx context.Context, userAccessToken string) (*Memb
 	return parseIdentity(raw)
 }
 
+func (c *Client) warnf(ctx context.Context, msg string, args ...any) {
+	if c.warn != nil {
+		c.warn(ctx, msg, args...)
+	}
+}
+
 func (c *Client) findMember(ctx context.Context, match func(*memberRow) bool) (*Membership, error) {
 	token, err := c.creatorAccessToken(ctx)
 	if err != nil {
@@ -179,8 +192,13 @@ func (c *Client) findMember(ctx context.Context, match func(*memberRow) bool) (*
 		if err != nil {
 			// A 404 from one campaign's member endpoint (invalid, deleted,
 			// or inaccessible to this token) must not abort the search — a
-			// backer may exist only in a later campaign.
+			// backer may exist only in a later campaign. It is, however,
+			// indistinguishable from a misconfigured campaign id, so surface
+			// it to operators: if every configured id 404s, genuine patrons
+			// silently resolve as not-found (or free, with infer_unknown_as_free).
 			if errors.Is(err, ErrMemberNotFound) {
+				c.warnf(ctx, "patreon members endpoint returned 404; campaign id may be misconfigured, deleted, or inaccessible to this token",
+					"campaign_id", campaignID)
 				continue
 			}
 			return nil, err
@@ -235,6 +253,12 @@ func (c *Client) listCampaigns(ctx context.Context, token string) ([]string, err
 		} `json:"data"`
 	}
 	if err := c.doJSON(ctx, http.MethodGet, u, token, &resp); err != nil {
+		// A 404 from the campaigns-listing endpoint is not "member not
+		// found" — the listing itself failed, which is an availability or
+		// token-scope problem and must not read as a benign miss.
+		if errors.Is(err, ErrMemberNotFound) {
+			return nil, fmt.Errorf("%w: campaigns listing returned 404", ErrPatreonUnavailable)
+		}
 		return nil, err
 	}
 	ids := make([]string, 0, len(resp.Data))

--- a/service/entityresolution/patreon/v2/entity_resolution.go
+++ b/service/entityresolution/patreon/v2/entity_resolution.go
@@ -1,0 +1,371 @@
+package patreon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/opentdf/platform/protocol/go/entity"
+	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	ent "github.com/opentdf/platform/service/entity"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/config"
+	"github.com/opentdf/platform/service/pkg/serviceregistry"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Default JWT claim names used to locate the Patreon identity on inbound
+// tokens. Overridable via Config.JWT.*.
+const (
+	defaultPatreonUserIDClaim = "patreon_user_id"
+	defaultUsernameClaim      = "preferred_username"
+	defaultClientIDClaim      = "azp"
+	defaultPatreonTokenClaim  = "patreon_access_token"
+)
+
+// Config configures the Patreon entity resolution provider.
+type Config struct {
+	APIBase            string    `mapstructure:"api_base" json:"api_base"`
+	TokenURL           string    `mapstructure:"token_url" json:"token_url"`
+	ClientID           string    `mapstructure:"client_id" json:"client_id"`
+	ClientSecret       string    `mapstructure:"client_secret" json:"client_secret"`
+	CreatorAccessToken string    `mapstructure:"creator_access_token" json:"creator_access_token"`
+	CampaignIDs        []string  `mapstructure:"campaign_ids" json:"campaign_ids"`
+	JWT                JWTConfig `mapstructure:"jwt" json:"jwt"`
+	// InferUnknownAsFree returns a free-tier membership instead of an error
+	// when the subject can't be matched in Patreon. Useful so unauthenticated
+	// or non-Patreon traffic still flows through subject mappings.
+	InferUnknownAsFree bool `mapstructure:"infer_unknown_as_free" json:"infer_unknown_as_free"`
+}
+
+// JWTConfig customizes which JWT claims the provider reads.
+type JWTConfig struct {
+	PatreonUserIDClaim string `mapstructure:"patreon_user_id_claim" json:"patreon_user_id_claim"`
+	UsernameClaim      string `mapstructure:"username_claim" json:"username_claim"`
+	ClientIDClaim      string `mapstructure:"client_id_claim" json:"client_id_claim"`
+	PatreonTokenClaim  string `mapstructure:"patreon_access_token_claim" json:"patreon_access_token_claim"`
+}
+
+// LogValue redacts secrets from log output.
+func (c Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("api_base", c.APIBase),
+		slog.String("token_url", c.TokenURL),
+		slog.String("client_id", c.ClientID),
+		slog.String("client_secret", redact(c.ClientSecret)),
+		slog.String("creator_access_token", redact(c.CreatorAccessToken)),
+		slog.Any("campaign_ids", c.CampaignIDs),
+		slog.Bool("infer_unknown_as_free", c.InferUnknownAsFree),
+	)
+}
+
+func redact(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "[REDACTED]"
+}
+
+// EntityResolutionService is the v2 Patreon entity resolver.
+type EntityResolutionService struct {
+	entityresolutionV2.UnimplementedEntityResolutionServiceServer
+	cfg    Config
+	client MembershipAPI
+	logger *logger.Logger
+	trace.Tracer
+}
+
+// MembershipAPI is the subset of *Client the resolver depends on (extracted
+// for unit testing).
+type MembershipAPI interface {
+	ResolveByUserID(ctx context.Context, userID string) (*Membership, error)
+	ResolveByEmail(ctx context.Context, email string) (*Membership, error)
+	ResolveSelf(ctx context.Context, userAccessToken string) (*Membership, error)
+}
+
+// RegisterPatreonERS adapts the Patreon ERS to the platform serviceregistry.
+func RegisterPatreonERS(cfg config.ServiceConfig, log *logger.Logger) (*EntityResolutionService, serviceregistry.HandlerServer) {
+	var c Config
+	if err := mapstructure.Decode(cfg, &c); err != nil {
+		log.Error("failed to decode patreon entity resolution config", slog.Any("error", err))
+		panic(fmt.Sprintf("failed to decode patreon entity resolution config: %v", err))
+	}
+	applyJWTDefaults(&c.JWT)
+	log.Debug("patreon entity resolution configuration", slog.Any("config", c))
+
+	client := NewClient(ClientOptions{
+		APIBase:            c.APIBase,
+		TokenURL:           c.TokenURL,
+		ClientID:           c.ClientID,
+		ClientSecret:       c.ClientSecret,
+		CreatorAccessToken: c.CreatorAccessToken,
+		CampaignIDs:        c.CampaignIDs,
+	})
+	return &EntityResolutionService{cfg: c, client: client, logger: log}, nil
+}
+
+// NewERSWithClient is the test-friendly constructor.
+func NewERSWithClient(cfg Config, client MembershipAPI, log *logger.Logger) *EntityResolutionService {
+	applyJWTDefaults(&cfg.JWT)
+	return &EntityResolutionService{cfg: cfg, client: client, logger: log}
+}
+
+func applyJWTDefaults(j *JWTConfig) {
+	if j.PatreonUserIDClaim == "" {
+		j.PatreonUserIDClaim = defaultPatreonUserIDClaim
+	}
+	if j.UsernameClaim == "" {
+		j.UsernameClaim = defaultUsernameClaim
+	}
+	if j.ClientIDClaim == "" {
+		j.ClientIDClaim = defaultClientIDClaim
+	}
+	if j.PatreonTokenClaim == "" {
+		j.PatreonTokenClaim = defaultPatreonTokenClaim
+	}
+}
+
+// ResolveEntities looks each requested entity up in Patreon and returns the
+// resolved membership wrapped as additional claims under a "patreon" key,
+// matching the .patreon.* selectors used by subject mappings.
+func (s *EntityResolutionService) ResolveEntities(
+	ctx context.Context,
+	req *connect.Request[entityresolutionV2.ResolveEntitiesRequest],
+) (*connect.Response[entityresolutionV2.ResolveEntitiesResponse], error) {
+	ctx, span := s.Start(ctx, "ResolveEntities")
+	defer span.End()
+
+	payload := req.Msg.GetEntities()
+	resolved := make([]*entityresolutionV2.EntityRepresentation, 0, len(payload))
+
+	for idx, ident := range payload {
+		originalID := ident.GetEphemeralId()
+		if originalID == "" {
+			originalID = ent.EntityIDPrefix + strconv.Itoa(idx)
+		}
+
+		mem, err := s.resolveEntity(ctx, ident)
+		if err != nil {
+			if errors.Is(err, ErrMemberNotFound) && s.cfg.InferUnknownAsFree {
+				mem = freeMembership(ident)
+			} else {
+				s.logger.WarnContext(ctx, "patreon resolve failed",
+					slog.String("entity_id", originalID),
+					slog.String("error", err.Error()))
+				return nil, connect.NewError(connectCodeFor(err), err)
+			}
+		}
+
+		repr, err := membershipToRepresentation(originalID, mem)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		resolved = append(resolved, repr)
+	}
+
+	return connect.NewResponse(&entityresolutionV2.ResolveEntitiesResponse{
+		EntityRepresentations: resolved,
+	}), nil
+}
+
+// CreateEntityChainsFromTokens builds an entity chain per JWT: an environment
+// entity for the client id and a subject entity carrying the user's Patreon
+// membership claims (resolved via the JWT's identity hints).
+func (s *EntityResolutionService) CreateEntityChainsFromTokens(
+	ctx context.Context,
+	req *connect.Request[entityresolutionV2.CreateEntityChainsFromTokensRequest],
+) (*connect.Response[entityresolutionV2.CreateEntityChainsFromTokensResponse], error) {
+	ctx, span := s.Start(ctx, "CreateEntityChainsFromTokens")
+	defer span.End()
+
+	chains := make([]*entity.EntityChain, 0, len(req.Msg.GetTokens()))
+	for _, tok := range req.Msg.GetTokens() {
+		entities, err := s.entitiesFromToken(ctx, tok.GetJwt())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		chains = append(chains, &entity.EntityChain{
+			EphemeralId: tok.GetEphemeralId(),
+			Entities:    entities,
+		})
+	}
+	return connect.NewResponse(&entityresolutionV2.CreateEntityChainsFromTokensResponse{
+		EntityChains: chains,
+	}), nil
+}
+
+func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtString string) ([]*entity.Entity, error) {
+	parsed, err := jwt.ParseString(jwtString, jwt.WithVerify(false), jwt.WithValidate(false))
+	if err != nil {
+		return nil, fmt.Errorf("parse jwt: %w", err)
+	}
+	claims, err := parsed.AsMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read jwt claims: %w", err)
+	}
+
+	out := []*entity.Entity{}
+	if v, ok := claims[s.cfg.JWT.ClientIDClaim].(string); ok && v != "" {
+		out = append(out, &entity.Entity{
+			EntityType:  &entity.Entity_ClientId{ClientId: v},
+			EphemeralId: "patreon-clientid-" + v,
+			Category:    entity.Entity_CATEGORY_ENVIRONMENT,
+		})
+	}
+
+	mem, err := s.resolveFromClaims(ctx, claims)
+	switch {
+	case errors.Is(err, ErrMemberNotFound) && s.cfg.InferUnknownAsFree:
+		mem = &Membership{TierSlug: "free", Status: "former"}
+	case err != nil:
+		return nil, err
+	}
+
+	patreonStruct, err := membershipStruct(mem)
+	if err != nil {
+		return nil, err
+	}
+	subjectClaims, err := structpb.NewStruct(map[string]interface{}{
+		"patreon": patreonStruct.AsMap(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	anyClaims, err := anypb.New(subjectClaims)
+	if err != nil {
+		return nil, err
+	}
+	id := mem.UserID
+	if id == "" {
+		id = mem.Email
+	}
+	if id == "" {
+		id = "anonymous"
+	}
+	out = append(out, &entity.Entity{
+		EntityType:  &entity.Entity_Claims{Claims: anyClaims},
+		EphemeralId: "patreon-subject-" + id,
+		Category:    entity.Entity_CATEGORY_SUBJECT,
+	})
+	return out, nil
+}
+
+// resolveEntity routes a single ResolveEntities request entry through the
+// best lookup strategy for its type.
+func (s *EntityResolutionService) resolveEntity(ctx context.Context, e *entity.Entity) (*Membership, error) {
+	switch et := e.GetEntityType().(type) {
+	case *entity.Entity_UserName:
+		return s.client.ResolveByUserID(ctx, et.UserName)
+	case *entity.Entity_EmailAddress:
+		return s.client.ResolveByEmail(ctx, et.EmailAddress)
+	case *entity.Entity_ClientId:
+		// Treat client id as a Patreon user id (callers can override claims).
+		return s.client.ResolveByUserID(ctx, et.ClientId)
+	case *entity.Entity_Claims:
+		var asStruct structpb.Struct
+		if err := e.GetClaims().UnmarshalTo(&asStruct); err != nil {
+			return nil, fmt.Errorf("unpack claims: %w", err)
+		}
+		return s.resolveFromClaims(ctx, asStruct.AsMap())
+	default:
+		return nil, fmt.Errorf("%w: unsupported entity type %T", ErrMemberNotFound, et)
+	}
+}
+
+func (s *EntityResolutionService) resolveFromClaims(ctx context.Context, claims map[string]interface{}) (*Membership, error) {
+	if tok, ok := claims[s.cfg.JWT.PatreonTokenClaim].(string); ok && tok != "" {
+		return s.client.ResolveSelf(ctx, tok)
+	}
+	if uid, ok := claims[s.cfg.JWT.PatreonUserIDClaim].(string); ok && uid != "" {
+		return s.client.ResolveByUserID(ctx, uid)
+	}
+	if email, ok := claims["email"].(string); ok && email != "" {
+		return s.client.ResolveByEmail(ctx, email)
+	}
+	if username, ok := claims[s.cfg.JWT.UsernameClaim].(string); ok && username != "" {
+		if strings.Contains(username, "@") {
+			return s.client.ResolveByEmail(ctx, username)
+		}
+		return s.client.ResolveByUserID(ctx, username)
+	}
+	return nil, ErrMemberNotFound
+}
+
+// freeMembership returns a synthetic free-tier membership tied to the
+// caller identity, used when InferUnknownAsFree is set.
+func freeMembership(e *entity.Entity) *Membership {
+	mem := &Membership{TierSlug: "free", Status: "former"}
+	switch et := e.GetEntityType().(type) {
+	case *entity.Entity_UserName:
+		mem.UserID = et.UserName
+	case *entity.Entity_EmailAddress:
+		mem.Email = et.EmailAddress
+	}
+	return mem
+}
+
+func membershipStruct(mem *Membership) (*structpb.Struct, error) {
+	m := map[string]interface{}{
+		"user_id":           mem.UserID,
+		"email":             mem.Email,
+		"full_name":         mem.FullName,
+		"status":            mem.Status,
+		"tier_slug":         mem.TierSlug,
+		"tier_amount_cents": mem.TierAmount,
+		"campaign_ids":      toIfaceSlice(mem.CampaignIDs),
+		"benefits":          toIfaceSlice(mem.Benefits),
+	}
+	if mem.PledgeStart != "" {
+		m["pledge_start"] = mem.PledgeStart
+	}
+	if mem.LastChargeAt != "" {
+		m["last_charge_at"] = mem.LastChargeAt
+	}
+	return structpb.NewStruct(m)
+}
+
+func membershipToRepresentation(originalID string, mem *Membership) (*entityresolutionV2.EntityRepresentation, error) {
+	patreonStruct, err := membershipStruct(mem)
+	if err != nil {
+		return nil, err
+	}
+	wrapped, err := structpb.NewStruct(map[string]interface{}{
+		"patreon": patreonStruct.AsMap(),
+		"id":      mem.UserID,
+		"email":   mem.Email,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &entityresolutionV2.EntityRepresentation{
+		OriginalId:      originalID,
+		AdditionalProps: []*structpb.Struct{wrapped},
+	}, nil
+}
+
+func toIfaceSlice(in []string) []interface{} {
+	out := make([]interface{}, len(in))
+	for i, v := range in {
+		out[i] = v
+	}
+	return out
+}
+
+func connectCodeFor(err error) connect.Code {
+	switch {
+	case errors.Is(err, ErrMemberNotFound):
+		return connect.CodeNotFound
+	case errors.Is(err, ErrPatreonUnavailable):
+		return connect.CodeUnavailable
+	default:
+		return connect.CodeInternal
+	}
+}

--- a/service/entityresolution/patreon/v2/entity_resolution.go
+++ b/service/entityresolution/patreon/v2/entity_resolution.go
@@ -224,7 +224,7 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtStri
 	mem, err := s.resolveFromClaims(ctx, claims)
 	switch {
 	case errors.Is(err, ErrMemberNotFound) && s.cfg.InferUnknownAsFree:
-		mem = &Membership{TierSlug: "free", Status: "former"}
+		mem = &Membership{TierSlug: tierFree, Status: statusFormer}
 	case err != nil:
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (s *EntityResolutionService) resolveFromClaims(ctx context.Context, claims 
 // freeMembership returns a synthetic free-tier membership tied to the
 // caller identity, used when InferUnknownAsFree is set.
 func freeMembership(e *entity.Entity) *Membership {
-	mem := &Membership{TierSlug: "free", Status: "former"}
+	mem := &Membership{TierSlug: tierFree, Status: statusFormer}
 	switch et := e.GetEntityType().(type) {
 	case *entity.Entity_UserName:
 		mem.UserID = et.UserName

--- a/service/entityresolution/patreon/v2/entity_resolution.go
+++ b/service/entityresolution/patreon/v2/entity_resolution.go
@@ -108,6 +108,7 @@ func RegisterPatreonERS(cfg config.ServiceConfig, log *logger.Logger) (*EntityRe
 		ClientSecret:       c.ClientSecret,
 		CreatorAccessToken: c.CreatorAccessToken,
 		CampaignIDs:        c.CampaignIDs,
+		Warn:               log.WarnContext,
 	})
 	return &EntityResolutionService{cfg: c, client: client, logger: log}, nil
 }

--- a/service/entityresolution/patreon/v2/entity_resolution_test.go
+++ b/service/entityresolution/patreon/v2/entity_resolution_test.go
@@ -1,0 +1,294 @@
+package patreon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/opentdf/platform/protocol/go/entity"
+	ersV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	"github.com/opentdf/platform/service/logger"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func newSvc(t *testing.T, cfg Config, client MembershipAPI) *EntityResolutionService {
+	t.Helper()
+	svc := NewERSWithClient(cfg, client, testLogger(t))
+	svc.Tracer = noop.NewTracerProvider().Tracer("test")
+	return svc
+}
+
+type stubClient struct {
+	byID    map[string]*Membership
+	byEmail map[string]*Membership
+	self    map[string]*Membership
+}
+
+func (s *stubClient) ResolveByUserID(_ context.Context, id string) (*Membership, error) {
+	if m, ok := s.byID[id]; ok {
+		return m, nil
+	}
+	return nil, ErrMemberNotFound
+}
+
+func (s *stubClient) ResolveByEmail(_ context.Context, email string) (*Membership, error) {
+	if m, ok := s.byEmail[strings.ToLower(email)]; ok {
+		return m, nil
+	}
+	return nil, ErrMemberNotFound
+}
+
+func (s *stubClient) ResolveSelf(_ context.Context, tok string) (*Membership, error) {
+	if m, ok := s.self[tok]; ok {
+		return m, nil
+	}
+	return nil, ErrMemberNotFound
+}
+
+func testLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	l, err := logger.NewLogger(logger.Config{Level: "debug", Output: "stdout", Type: "text"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	return l
+}
+
+func TestResolveEntities_ByUserID(t *testing.T) {
+	stub := &stubClient{byID: map[string]*Membership{
+		"u123": {
+			UserID: "u123", Email: "a@b.test", TierSlug: "patron",
+			TierAmount: 1000, Status: "active",
+			CampaignIDs: []string{"arkavo"},
+			Benefits:    []string{"early-access", "exclusive-content"},
+		},
+	}}
+	svc := newSvc(t, Config{}, stub)
+
+	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "e0",
+			EntityType:  &entity.Entity_UserName{UserName: "u123"},
+		}},
+	})
+	resp, err := svc.ResolveEntities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ResolveEntities: %v", err)
+	}
+	reprs := resp.Msg.GetEntityRepresentations()
+	if len(reprs) != 1 {
+		t.Fatalf("want 1 representation, got %d", len(reprs))
+	}
+	props := reprs[0].GetAdditionalProps()
+	if len(props) != 1 {
+		t.Fatalf("want 1 props struct, got %d", len(props))
+	}
+	got := props[0].AsMap()
+	patreon, ok := got["patreon"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected patreon map, got %T", got["patreon"])
+	}
+	if patreon["tier_slug"] != "patron" {
+		t.Errorf("tier_slug = %v, want patron", patreon["tier_slug"])
+	}
+	if patreon["status"] != "active" {
+		t.Errorf("status = %v, want active", patreon["status"])
+	}
+}
+
+func TestResolveEntities_UnknownInfersFree(t *testing.T) {
+	svc := newSvc(t, Config{InferUnknownAsFree: true}, &stubClient{})
+	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "e0",
+			EntityType:  &entity.Entity_EmailAddress{EmailAddress: "nobody@nowhere"},
+		}},
+	})
+	resp, err := svc.ResolveEntities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ResolveEntities: %v", err)
+	}
+	patreon, ok := resp.Msg.GetEntityRepresentations()[0].GetAdditionalProps()[0].AsMap()["patreon"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("patreon key missing or wrong type")
+	}
+	if patreon["tier_slug"] != "free" {
+		t.Errorf("tier_slug = %v, want free", patreon["tier_slug"])
+	}
+}
+
+func TestResolveEntities_UnknownErrors(t *testing.T) {
+	svc := newSvc(t, Config{InferUnknownAsFree: false}, &stubClient{})
+	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "e0",
+			EntityType:  &entity.Entity_EmailAddress{EmailAddress: "nobody@nowhere"},
+		}},
+	})
+	_, err := svc.ResolveEntities(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for unknown subject without infer")
+	}
+	if got := connect.CodeOf(err); got != connect.CodeNotFound {
+		t.Errorf("code = %v, want NotFound", got)
+	}
+	if !errors.Is(err, ErrMemberNotFound) {
+		t.Errorf("err = %v, want ErrMemberNotFound underlying", err)
+	}
+}
+
+func TestParseMembersPage(t *testing.T) {
+	payload := `{
+	  "data": [
+	    {
+	      "id": "m1",
+	      "type": "member",
+	      "attributes": {
+	        "email": "fan@example.com",
+	        "full_name": "Fan One",
+	        "patron_status": "active_patron",
+	        "currently_entitled_amount_cents": 500,
+	        "last_charge_date": "2024-05-01T00:00:00Z"
+	      },
+	      "relationships": {
+	        "user":                     {"data": {"id":"u1","type":"user"}},
+	        "currently_entitled_tiers": {"data": [{"id":"t1","type":"tier"}]}
+	      }
+	    }
+	  ],
+	  "included": [
+	    {"id":"u1","type":"user","attributes":{"email":"fan@example.com","full_name":"Fan One"}},
+	    {"id":"t1","type":"tier","attributes":{"title":"Supporter","amount_cents":500},
+	     "relationships":{"benefits":{"data":[{"id":"b1","type":"benefit"},{"id":"b2","type":"benefit"}]}}},
+	    {"id":"b1","type":"benefit","attributes":{"title":"Early Access"}},
+	    {"id":"b2","type":"benefit","attributes":{"title":"Exclusive Content"}}
+	  ],
+	  "meta": {"pagination":{"cursors":{"next":""}}}
+	}`
+	page, err := parseMembersPage(json.RawMessage(payload))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(page.members) != 1 {
+		t.Fatalf("want 1 member, got %d", len(page.members))
+	}
+	m := page.members[0]
+	if m.userID != "u1" || m.email != "fan@example.com" {
+		t.Errorf("user/email mismatch: %+v", m)
+	}
+	if m.tierSlug != "supporter" {
+		t.Errorf("tier_slug = %q, want supporter", m.tierSlug)
+	}
+	if got := strings.Join(m.benefits, ","); got != "early-access,exclusive-content" {
+		t.Errorf("benefits = %q, want early-access,exclusive-content", got)
+	}
+	mem := m.toMembership("arkavo")
+	if mem.Status != "active" {
+		t.Errorf("status = %q, want active", mem.Status)
+	}
+	if len(mem.CampaignIDs) != 1 || mem.CampaignIDs[0] != "arkavo" {
+		t.Errorf("campaign_ids = %v, want [arkavo]", mem.CampaignIDs)
+	}
+}
+
+func TestParseIdentity(t *testing.T) {
+	payload := `{
+	  "data": {
+	    "id": "u42",
+	    "type": "user",
+	    "attributes": {"email":"vip@example.com","full_name":"VIP"},
+	    "relationships": {"memberships": {"data": [{"id":"m99","type":"member"}]}}
+	  },
+	  "included": [
+	    {"id":"m99","type":"member","attributes":{"patron_status":"active_patron","currently_entitled_amount_cents":5000},
+	     "relationships":{"campaign":{"data":{"id":"arkavo","type":"campaign"}},
+	                      "currently_entitled_tiers":{"data":[{"id":"t9","type":"tier"}]}}},
+	    {"id":"t9","type":"tier","attributes":{"title":"VIP","amount_cents":5000},
+	     "relationships":{"benefits":{"data":[{"id":"b9","type":"benefit"}]}}},
+	    {"id":"b9","type":"benefit","attributes":{"title":"Discord"}}
+	  ]
+	}`
+	mem, err := parseIdentity(json.RawMessage(payload))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if mem.TierSlug != "vip" {
+		t.Errorf("tier_slug = %q, want vip", mem.TierSlug)
+	}
+	if mem.Status != "active" {
+		t.Errorf("status = %q, want active", mem.Status)
+	}
+	if len(mem.CampaignIDs) != 1 || mem.CampaignIDs[0] != "arkavo" {
+		t.Errorf("campaign_ids = %v, want [arkavo]", mem.CampaignIDs)
+	}
+	if len(mem.Benefits) != 1 || mem.Benefits[0] != "discord" {
+		t.Errorf("benefits = %v, want [discord]", mem.Benefits)
+	}
+}
+
+func TestClient_ResolveByEmail_PaginatesAndMatches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("page[cursor]")
+		w.Header().Set("Content-Type", "application/json")
+		switch cursor {
+		case "":
+			_, _ = w.Write([]byte(`{
+				"data": [{"id":"m1","type":"member","attributes":{},"relationships":{"user":{"data":{"id":"u1","type":"user"}}}}],
+				"included": [{"id":"u1","type":"user","attributes":{"email":"alice@example.com"}}],
+				"meta": {"pagination":{"cursors":{"next":"page2"}}}
+			}`))
+		case "page2":
+			_, _ = w.Write([]byte(`{
+				"data": [{"id":"m2","type":"member","attributes":{"patron_status":"active_patron","currently_entitled_amount_cents":2500},
+				          "relationships":{"user":{"data":{"id":"u2","type":"user"}},
+				                           "currently_entitled_tiers":{"data":[{"id":"t1","type":"tier"}]}}}],
+				"included": [
+				  {"id":"u2","type":"user","attributes":{"email":"bob@example.com","full_name":"Bob"}},
+				  {"id":"t1","type":"tier","attributes":{"title":"Patron","amount_cents":2500}}
+				],
+				"meta": {"pagination":{"cursors":{"next":""}}}
+			}`))
+		default:
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientOptions{
+		APIBase:            server.URL,
+		CreatorAccessToken: "fake-creator-token",
+		CampaignIDs:        []string{"arkavo"},
+	})
+	mem, err := c.ResolveByEmail(context.Background(), "BOB@example.com")
+	if err != nil {
+		t.Fatalf("ResolveByEmail: %v", err)
+	}
+	if mem.UserID != "u2" {
+		t.Errorf("user_id = %q, want u2", mem.UserID)
+	}
+	if mem.TierSlug != "patron" {
+		t.Errorf("tier_slug = %q, want patron", mem.TierSlug)
+	}
+	if mem.Status != "active" {
+		t.Errorf("status = %q, want active", mem.Status)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"VIP", "vip"},
+		{"Early Access", "early-access"},
+		{"  Behind The Scenes  ", "behind-the-scenes"},
+		{"!!!", ""},
+		{"foo--bar", "foo-bar"},
+	} {
+		if got := slugify(tc.in); got != tc.want {
+			t.Errorf("slugify(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/service/entityresolution/patreon/v2/entity_resolution_test.go
+++ b/service/entityresolution/patreon/v2/entity_resolution_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -276,6 +278,92 @@ func TestClient_ResolveByEmail_PaginatesAndMatches(t *testing.T) {
 	}
 	if mem.Status != "active" {
 		t.Errorf("status = %q, want active", mem.Status)
+	}
+}
+
+func TestClient_FindMember_SkipsCampaign404(t *testing.T) {
+	// A 404 from one campaign's member endpoint (deleted/inaccessible id)
+	// must not abort the search — the backer here exists only in the second
+	// configured campaign.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/campaigns/dead/"):
+			http.Error(w, "not found", http.StatusNotFound)
+		case strings.Contains(r.URL.Path, "/campaigns/live/"):
+			_, _ = w.Write([]byte(`{
+				"data": [{"id":"m1","type":"member","attributes":{"patron_status":"active_patron"},
+				          "relationships":{"user":{"data":{"id":"u9","type":"user"}}}}],
+				"included": [{"id":"u9","type":"user","attributes":{"email":"carol@example.com"}}],
+				"meta": {"pagination":{"cursors":{"next":""}}}
+			}`))
+		default:
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientOptions{
+		APIBase:            server.URL,
+		CreatorAccessToken: "fake-creator-token",
+		CampaignIDs:        []string{"dead", "live"},
+	})
+	mem, err := c.ResolveByUserID(context.Background(), "u9")
+	if err != nil {
+		t.Fatalf("ResolveByUserID: %v", err)
+	}
+	if mem.UserID != "u9" {
+		t.Errorf("user_id = %q, want u9", mem.UserID)
+	}
+	if len(mem.CampaignIDs) != 1 || mem.CampaignIDs[0] != "live" {
+		t.Errorf("campaign_ids = %v, want [live]", mem.CampaignIDs)
+	}
+}
+
+func TestClient_CreatorToken_DefaultTTLAndSingleFetch(t *testing.T) {
+	// A token response without expires_in must still be cached (default TTL)
+	// rather than treated as immediately stale and re-fetched per request.
+	var tokenCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			atomic.AddInt32(&tokenCalls, 1)
+			_, _ = w.Write([]byte(`{"access_token":"cc-token"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{
+			"data": [{"id":"m1","type":"member","attributes":{},
+			          "relationships":{"user":{"data":{"id":"u1","type":"user"}}}}],
+			"included": [],
+			"meta": {"pagination":{"cursors":{"next":""}}}
+		}`))
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientOptions{
+		APIBase:      server.URL,
+		TokenURL:     server.URL + "/token",
+		ClientID:     "cid",
+		ClientSecret: "csecret",
+		CampaignIDs:  []string{"camp"},
+	})
+
+	// Concurrent lookups: refresh is single-flighted, then cached.
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.ResolveByUserID(context.Background(), "u1")
+		}()
+	}
+	wg.Wait()
+	if _, err := c.ResolveByUserID(context.Background(), "u1"); err != nil {
+		t.Fatalf("ResolveByUserID: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&tokenCalls); got != 1 {
+		t.Errorf("token endpoint called %d times, want 1 (cached with default TTL, single-flight refresh)", got)
 	}
 }
 

--- a/service/entityresolution/patreon/v2/entity_resolution_test.go
+++ b/service/entityresolution/patreon/v2/entity_resolution_test.go
@@ -303,10 +303,14 @@ func TestClient_FindMember_SkipsCampaign404(t *testing.T) {
 	}))
 	defer server.Close()
 
+	var warned []string
 	c := NewClient(ClientOptions{
 		APIBase:            server.URL,
 		CreatorAccessToken: "fake-creator-token",
 		CampaignIDs:        []string{"dead", "live"},
+		Warn: func(_ context.Context, msg string, _ ...any) {
+			warned = append(warned, msg)
+		},
 	})
 	mem, err := c.ResolveByUserID(context.Background(), "u9")
 	if err != nil {
@@ -317,6 +321,10 @@ func TestClient_FindMember_SkipsCampaign404(t *testing.T) {
 	}
 	if len(mem.CampaignIDs) != 1 || mem.CampaignIDs[0] != "live" {
 		t.Errorf("campaign_ids = %v, want [live]", mem.CampaignIDs)
+	}
+	// Operators must be able to tell "empty campaign" from "bad config".
+	if len(warned) != 1 {
+		t.Errorf("warn hook fired %d times, want 1 (for campaign id 'dead')", len(warned))
 	}
 }
 

--- a/service/entityresolution/v2/entity_resolution.go
+++ b/service/entityresolution/v2/entity_resolution.go
@@ -11,6 +11,7 @@ import (
 	claims "github.com/opentdf/platform/service/entityresolution/claims/v2"
 	keycloak "github.com/opentdf/platform/service/entityresolution/keycloak/v2"
 	multistrategyv2 "github.com/opentdf/platform/service/entityresolution/multi-strategy/v2"
+	patreonv2 "github.com/opentdf/platform/service/entityresolution/patreon/v2"
 	"github.com/opentdf/platform/service/pkg/cache"
 	"github.com/opentdf/platform/service/pkg/serviceregistry"
 	"go.opentelemetry.io/otel/trace"
@@ -25,6 +26,7 @@ const (
 	KeycloakMode      = "keycloak"
 	ClaimsMode        = "claims"
 	MultiStrategyMode = "multi-strategy"
+	PatreonMode       = "patreon"
 )
 
 type EntityResolution struct {
@@ -74,6 +76,10 @@ func NewRegistration() *serviceregistry.Service[entityresolutionv2connect.Entity
 					multiSVC, multiHandler := multistrategyv2.RegisterMultiStrategyERSV2(srp.Config, srp.Logger)
 					multiSVC.Tracer = srp.Tracer
 					return EntityResolution{EntityResolutionServiceHandler: multiSVC}, multiHandler
+				case PatreonMode:
+					patreonSVC, patreonHandler := patreonv2.RegisterPatreonERS(srp.Config, srp.Logger)
+					patreonSVC.Tracer = srp.Tracer
+					return EntityResolution{EntityResolutionServiceHandler: patreonSVC, Tracer: srp.Tracer}, patreonHandler
 				default:
 					// Default to Keycloak ERS with cache support
 					kcSVC, kcHandler := keycloak.RegisterKeycloakERS(srp.Config, srp.Logger, ersCache)

--- a/service/go.mod
+++ b/service/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/eko/gocache/lib/v4 v4.2.0
 	github.com/eko/gocache/store/ristretto/v4 v4.3.2
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-chi/cors v1.2.1
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-viper/mapstructure/v2 v2.4.0
@@ -41,6 +42,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
+	github.com/veraison/go-cose v1.3.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0
@@ -58,11 +60,9 @@ require (
 
 require (
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/moby/moby/api v1.54.1 // indirect
 	github.com/moby/moby/client v0.4.0 // indirect
-	github.com/veraison/go-cose v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 )
 


### PR DESCRIPTION
Introduce a Patreon-backed Entity Resolution Service that resolves a
subject's Patreon membership (tier, status, campaigns, benefits) and
surfaces it as policy claims under .patreon.*, plus a declarative
policy snapshot defining the patreon.arkavo.com namespace with
attributes for data tagging (classification, content-type), strict
entitlements (allOf), and Patreon-sourced subject attributes
(tier hierarchy, campaign anyOf, status).

- service/entityresolution/patreon/v2: new ERS mode "patreon" with a
  minimal Patreon v2 JSON:API client (member search by user id/email,
  identity lookup via forwarded user token, client_credentials token
  refresh, cursor pagination, tier->benefit relationship walking).
- service/entityresolution/v2: dispatch the new mode.
- examples/config/policy.patreon.yaml: namespace, attributes, values,
  and subject mappings keyed off the resolved Patreon claims.

Signed-off-by: Claude <noreply@anthropic.com>