### PR TITLE
feat(kas): register kas info in wellknown configuration

### DIFF
--- a/service/kas/kas.go
+++ b/service/kas/kas.go
@@ -119,10 +119,56 @@ func NewRegistration() *serviceregistry.Service[kasconnect.AccessServiceHandler]
 					srp.Logger.Error("failed to register kas readiness check", slog.String("error", err.Error()))
 				}
 
+				if err := registerKASWellKnown(srp, kasCfg); err != nil {
+					srp.Logger.Warn("failed to register kas wellknown config", slog.Any("error", err))
+				}
+
 				return p, nil
 			},
 		},
 	}
+}
+
+// registerKASWellKnown publishes a "kas" namespace in the platform's
+// well-known configuration so SDKs can discover the KAS URL, public-key
+// and rewrap endpoints, and supported key algorithms without out-of-band
+// configuration. Mirrors the registration pattern used by health/idp.
+//
+// The "algorithms" list excludes entries flagged legacy: true, since those
+// describe alternate key formats already covered by their non-legacy
+// sibling under the same kid. Returns nil if the registrar isn't wired up
+// (modes that skip the well-known service entirely).
+func registerKASWellKnown(srp serviceregistry.RegistrationParams, kasCfg access.KASConfig) error {
+	if srp.WellKnownConfig == nil {
+		return nil
+	}
+	kasURL, err := determineKASURL(srp, kasCfg)
+	if err != nil {
+		return fmt.Errorf("could not determine KAS URL: %w", err)
+	}
+	base := strings.TrimRight(kasURL.String(), "/")
+
+	seen := map[string]struct{}{}
+	algs := make([]string, 0, len(kasCfg.Keyring))
+	for _, k := range kasCfg.Keyring {
+		if k.Legacy || k.Algorithm == "" {
+			continue
+		}
+		if _, ok := seen[k.Algorithm]; ok {
+			continue
+		}
+		seen[k.Algorithm] = struct{}{}
+		algs = append(algs, k.Algorithm)
+	}
+
+	return srp.WellKnownConfig("kas", map[string]any{
+		"uri":                    base,
+		"public_key_url":         base + "/kas/v2/kas_public_key",
+		"connect_public_key_url": base + "/kas.AccessService/PublicKey",
+		"rewrap_url":             base + "/kas/v2/rewrap",
+		"connect_rewrap_url":     base + "/kas.AccessService/Rewrap",
+		"algorithms":             algs,
+	})
 }
 
 func determineKASURL(srp serviceregistry.RegistrationParams, kasCfg access.KASConfig) (*url.URL, error) {


### PR DESCRIPTION
## Summary

Adds a `kas` namespace to `/.well-known/opentdf-configuration` so SDKs and proxies can discover the KAS transport URLs and supported algorithms from a single endpoint, instead of relying on out-of-band config or per-TDF `kas_url` claims.

## Shape

```json
"kas": {
  "uri":                    "https://platform.arkavo.net",
  "public_key_url":         "https://platform.arkavo.net/kas/v2/kas_public_key",
  "connect_public_key_url": "https://platform.arkavo.net/kas.AccessService/PublicKey",
  "rewrap_url":             "https://platform.arkavo.net/kas/v2/rewrap",
  "connect_rewrap_url":     "https://platform.arkavo.net/kas.AccessService/Rewrap",
  "algorithms":             ["ec:secp256r1", "rsa:2048"]
}
```

`algorithms` is the deduplicated list of `alg` values from `services.kas.keyring`, excluding entries marked `legacy: true` (those describe alternate formats for an already-listed kid). `public_key_url` accepts `?algorithm=<alg>` per the existing endpoint contract — see CLAUDE.md note about RSA support.

## Why now / why not `base_key`

The existing `base_key` namespace (registered from `service/policy/db/key_access_server_registry.go:867`) is the closest thing today, but it's heavyweight:

1. Requires `policy` in `mode`
2. Requires Postgres
3. Requires `CreateKeyAccessServer` + `CreatePublicKey` + `SetBaseKey` admin API calls

KAS-only / `-policy` deployments (e.g. arkavo-org's loopback platform behind arks) got nothing about KAS from wellknown — even though the platform statically knows `registered_kas_uri` and the entire keyring from its yaml. This PR closes that gap with a runtime-config-driven registration.

## Implementation notes

- Single new helper `registerKASWellKnown` plus one call site in `NewRegistration`'s `RegisterFunc`.
- Re-uses the existing `determineKASURL` helper (already handles `RegisteredKASURI` → public_hostname+port+scheme fallback) so URL resolution stays in one place.
- Best-effort: log-warn and continue on failure. Wellknown is metadata; KAS serving shouldn't block on it.
- No new dependencies, no schema changes, no protocol changes. Pure additive.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./service/kas/...` — pass
- [x] `golangci-lint run ./service/kas/...` — no findings in new code (3 pre-existing in `access/rewrap.go` + `access/rewrap_test.go`)
- [ ] Smoke after deploy: `curl http://127.0.0.1:8181/.well-known/opentdf-configuration` shows the new `kas` block with the production URL and the EC + RSA algs from the keyring

🤖 Generated with [Claude Code](https://claude.com/claude-code)