### PR TITLE
feat(ers): claims-passthrough with campaign-qualified direct entitlements

### DIFF
--- a/examples/config/opentdf-patreon-local-test.yaml
+++ b/examples/config/opentdf-patreon-local-test.yaml
@@ -30,8 +30,8 @@ services:
     allow_direct_entitlements: true
   entityresolution:
     mode: patreon
-    api_base: http://127.0.0.1:9876
-    creator_access_token: test-creator-token
-    campaign_ids:
-      - "12345678"
+    # Multi-creator passthrough: trust the materialized arkavo_patreon claim
+    # and emit campaign-qualified direct entitlements. No Patreon creds needed.
+    trust_materialized_claims: true
+    trusted_issuer: http://127.0.0.1:9999
     infer_unknown_as_free: true

--- a/examples/config/opentdf-patreon-local-test.yaml
+++ b/examples/config/opentdf-patreon-local-test.yaml
@@ -25,6 +25,9 @@ server:
 services:
   authorization:
     policy_file: ./examples/config/policy.patreon.yaml
+    # Dynamic attribute values (synthetic) + ERS direct entitlements — the
+    # multi-creator SaaS path.
+    allow_direct_entitlements: true
   entityresolution:
     mode: patreon
     api_base: http://127.0.0.1:9876

--- a/examples/config/policy.patreon.yaml
+++ b/examples/config/policy.patreon.yaml
@@ -86,6 +86,19 @@ attributes:
       - value: declined
       - value: former
 
+  # campaign-tier gates content on a tier WITHIN a campaign, in the
+  # creator's own tier vocabulary: value format <campaign_id>_<tier_slug>
+  # (e.g. 12345678_gold-tier). Values are DYNAMIC — emitted as direct
+  # entitlements by the Patreon ERS claims-passthrough path and resolved as
+  # synthetic values (allow_direct_entitlements), so onboarding a creator
+  # needs no policy change; only this definition must exist. Content tagged
+  # "this tier and up" carries the explicit value list (anyOf) — the
+  # Creator app expands its own ladder at protect time.
+  - namespace: patreon.arkavo.com
+    name: campaign-tier
+    rule: anyOf
+    values: []
+
 subject_mappings:
   # tier mappings: each tier value matches when the Patreon ERS surfaces the
   # corresponding tier slug in the patreon.tier_slug claim.

--- a/service/entityresolution/patreon/v2/client.go
+++ b/service/entityresolution/patreon/v2/client.go
@@ -36,6 +36,8 @@ const (
 	statusActive   = "active"
 	statusDeclined = "declined"
 	statusFormer   = "former"
+	// Raw Patreon patron_status for an active pledge.
+	patronStatusActive = "active_patron"
 )
 
 var (
@@ -646,7 +648,7 @@ func parseIdentity(raw json.RawMessage) (*Membership, error) {
 
 func normalizeStatus(in string) string {
 	switch strings.ToLower(in) {
-	case "active_patron":
+	case patronStatusActive:
 		return statusActive
 	case "declined_patron":
 		return statusDeclined

--- a/service/entityresolution/patreon/v2/entity_resolution.go
+++ b/service/entityresolution/patreon/v2/entity_resolution.go
@@ -33,13 +33,16 @@ const (
 
 // Config configures the Patreon entity resolution provider.
 type Config struct {
-	APIBase            string    `mapstructure:"api_base" json:"api_base"`
-	TokenURL           string    `mapstructure:"token_url" json:"token_url"`
-	ClientID           string    `mapstructure:"client_id" json:"client_id"`
-	ClientSecret       string    `mapstructure:"client_secret" json:"client_secret"`
-	CreatorAccessToken string    `mapstructure:"creator_access_token" json:"creator_access_token"`
-	CampaignIDs        []string  `mapstructure:"campaign_ids" json:"campaign_ids"`
-	JWT                JWTConfig `mapstructure:"jwt" json:"jwt"`
+	APIBase            string   `mapstructure:"api_base" json:"api_base"`
+	TokenURL           string   `mapstructure:"token_url" json:"token_url"`
+	ClientID           string   `mapstructure:"client_id" json:"client_id"`
+	ClientSecret       string   `mapstructure:"client_secret" json:"client_secret"`
+	CreatorAccessToken string   `mapstructure:"creator_access_token" json:"creator_access_token"`
+	CampaignIDs        []string `mapstructure:"campaign_ids" json:"campaign_ids"`
+	// EntitlementsNamespace is the namespace for direct-entitlement FQNs
+	// emitted by the claims-passthrough path (default patreon.arkavo.com).
+	EntitlementsNamespace string    `mapstructure:"entitlements_namespace" json:"entitlements_namespace"`
+	JWT                   JWTConfig `mapstructure:"jwt" json:"jwt"`
 	// InferUnknownAsFree returns a free-tier membership instead of an error
 	// when the subject can't be matched in Patreon. Useful so unauthenticated
 	// or non-Patreon traffic still flows through subject mappings.
@@ -153,10 +156,10 @@ func (s *EntityResolutionService) ResolveEntities(
 			originalID = ent.EntityIDPrefix + strconv.Itoa(idx)
 		}
 
-		mem, err := s.resolveEntity(ctx, ident)
+		res, err := s.resolveEntity(ctx, ident)
 		if err != nil {
 			if errors.Is(err, ErrMemberNotFound) && s.cfg.InferUnknownAsFree {
-				mem = freeMembership(ident)
+				res = &resolution{mem: freeMembership(ident)}
 			} else {
 				s.logger.WarnContext(ctx, "patreon resolve failed",
 					slog.String("entity_id", originalID),
@@ -165,7 +168,7 @@ func (s *EntityResolutionService) ResolveEntities(
 			}
 		}
 
-		repr, err := membershipToRepresentation(originalID, mem)
+		repr, err := resolutionToRepresentation(originalID, res)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
@@ -222,21 +225,30 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtStri
 		})
 	}
 
-	mem, err := s.resolveFromClaims(ctx, claims)
+	res, err := s.resolveFromClaims(ctx, claims)
 	switch {
 	case errors.Is(err, ErrMemberNotFound) && s.cfg.InferUnknownAsFree:
-		mem = &Membership{TierSlug: tierFree, Status: statusFormer}
+		res = &resolution{mem: &Membership{TierSlug: tierFree, Status: statusFormer}}
 	case err != nil:
 		return nil, err
 	}
+	mem := res.mem
 
 	patreonStruct, err := membershipStruct(mem)
 	if err != nil {
 		return nil, err
 	}
-	subjectClaims, err := structpb.NewStruct(map[string]interface{}{
+	wrappedClaims := map[string]interface{}{
 		"patreon": patreonStruct.AsMap(),
-	})
+	}
+	// Preserve the materialized claim verbatim so the decision flow's
+	// second pass (ResolveEntities over the chain entities) re-derives the
+	// claims-passthrough resolution — including its direct entitlements —
+	// without ever consulting Patreon.
+	if raw, ok := claims["arkavo_patreon"].(map[string]interface{}); ok {
+		wrappedClaims["arkavo_patreon"] = raw
+	}
+	subjectClaims, err := structpb.NewStruct(wrappedClaims)
 	if err != nil {
 		return nil, err
 	}
@@ -261,15 +273,15 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtStri
 
 // resolveEntity routes a single ResolveEntities request entry through the
 // best lookup strategy for its type.
-func (s *EntityResolutionService) resolveEntity(ctx context.Context, e *entity.Entity) (*Membership, error) {
+func (s *EntityResolutionService) resolveEntity(ctx context.Context, e *entity.Entity) (*resolution, error) {
 	switch et := e.GetEntityType().(type) {
 	case *entity.Entity_UserName:
-		return s.client.ResolveByUserID(ctx, et.UserName)
+		return liveResolution(s.client.ResolveByUserID(ctx, et.UserName))
 	case *entity.Entity_EmailAddress:
-		return s.client.ResolveByEmail(ctx, et.EmailAddress)
+		return liveResolution(s.client.ResolveByEmail(ctx, et.EmailAddress))
 	case *entity.Entity_ClientId:
 		// Treat client id as a Patreon user id (callers can override claims).
-		return s.client.ResolveByUserID(ctx, et.ClientId)
+		return liveResolution(s.client.ResolveByUserID(ctx, et.ClientId))
 	case *entity.Entity_Claims:
 		var asStruct structpb.Struct
 		if err := e.GetClaims().UnmarshalTo(&asStruct); err != nil {
@@ -281,21 +293,36 @@ func (s *EntityResolutionService) resolveEntity(ctx context.Context, e *entity.E
 	}
 }
 
-func (s *EntityResolutionService) resolveFromClaims(ctx context.Context, claims map[string]interface{}) (*Membership, error) {
+// liveResolution wraps a live Patreon lookup (no direct entitlements — those
+// require the materialized multi-campaign claim).
+func liveResolution(mem *Membership, err error) (*resolution, error) {
+	if err != nil {
+		return nil, err
+	}
+	return &resolution{mem: mem}, nil
+}
+
+func (s *EntityResolutionService) resolveFromClaims(ctx context.Context, claims map[string]interface{}) (*resolution, error) {
+	// Claims-passthrough (SaaS multi-creator path): pre-materialized
+	// memberships from identity.arkavo.net need no Patreon access and emit
+	// campaign-qualified direct entitlements. See passthrough.go.
+	if claim := parseArkavoPatreon(claims); claim != nil {
+		return passthroughResolution(claim, s.cfg.entitlementsNamespace()), nil
+	}
 	if tok, ok := claims[s.cfg.JWT.PatreonTokenClaim].(string); ok && tok != "" {
-		return s.client.ResolveSelf(ctx, tok)
+		return liveResolution(s.client.ResolveSelf(ctx, tok))
 	}
 	if uid, ok := claims[s.cfg.JWT.PatreonUserIDClaim].(string); ok && uid != "" {
-		return s.client.ResolveByUserID(ctx, uid)
+		return liveResolution(s.client.ResolveByUserID(ctx, uid))
 	}
 	if email, ok := claims["email"].(string); ok && email != "" {
-		return s.client.ResolveByEmail(ctx, email)
+		return liveResolution(s.client.ResolveByEmail(ctx, email))
 	}
 	if username, ok := claims[s.cfg.JWT.UsernameClaim].(string); ok && username != "" {
 		if strings.Contains(username, "@") {
-			return s.client.ResolveByEmail(ctx, username)
+			return liveResolution(s.client.ResolveByEmail(ctx, username))
 		}
-		return s.client.ResolveByUserID(ctx, username)
+		return liveResolution(s.client.ResolveByUserID(ctx, username))
 	}
 	return nil, ErrMemberNotFound
 }
@@ -333,7 +360,8 @@ func membershipStruct(mem *Membership) (*structpb.Struct, error) {
 	return structpb.NewStruct(m)
 }
 
-func membershipToRepresentation(originalID string, mem *Membership) (*entityresolutionV2.EntityRepresentation, error) {
+func resolutionToRepresentation(originalID string, res *resolution) (*entityresolutionV2.EntityRepresentation, error) {
+	mem := res.mem
 	patreonStruct, err := membershipStruct(mem)
 	if err != nil {
 		return nil, err
@@ -346,9 +374,22 @@ func membershipToRepresentation(originalID string, mem *Membership) (*entityreso
 	if err != nil {
 		return nil, err
 	}
+	// Campaign-qualified direct entitlements from the claims-passthrough
+	// path. The PDP merges these with subject-mapping entitlements when
+	// allow_direct_entitlements is enabled; with synthetic-value support,
+	// only the attribute definitions need to exist in policy — values are
+	// fully dynamic, so onboarding a creator requires zero policy changes.
+	var direct []*entityresolutionV2.DirectEntitlement
+	for _, fqn := range res.entitlements {
+		direct = append(direct, &entityresolutionV2.DirectEntitlement{
+			AttributeValueFqn: fqn,
+			Actions:           []string{"read"},
+		})
+	}
 	return &entityresolutionV2.EntityRepresentation{
-		OriginalId:      originalID,
-		AdditionalProps: []*structpb.Struct{wrapped},
+		OriginalId:         originalID,
+		AdditionalProps:    []*structpb.Struct{wrapped},
+		DirectEntitlements: direct,
 	}, nil
 }
 

--- a/service/entityresolution/patreon/v2/entity_resolution.go
+++ b/service/entityresolution/patreon/v2/entity_resolution.go
@@ -47,6 +47,30 @@ type Config struct {
 	// when the subject can't be matched in Patreon. Useful so unauthenticated
 	// or non-Patreon traffic still flows through subject mappings.
 	InferUnknownAsFree bool `mapstructure:"infer_unknown_as_free" json:"infer_unknown_as_free"`
+	// TrustMaterializedClaims enables the claims-passthrough path: when an
+	// entity's claims already carry the arkavo_patreon materialization, emit
+	// campaign-qualified direct entitlements from it WITHOUT calling Patreon.
+	//
+	// SECURITY — this is the real trust control, default false. The
+	// materialized claim is honored as authoritative, so it must only ever
+	// reach this provider through a cryptographically trusted channel:
+	//   - the platform's own decision flow, where the subject token's
+	//     signature was verified by the authn interceptor before the ERS
+	//     re-parses it (and entitiesFromToken additionally pins the token's
+	//     issuer to TrustedIssuer below); or
+	//   - an entityChain submitted by a PEP that authenticated with a
+	//     role:standard credential and is trusted to have verified the
+	//     subject token itself (e.g. the catalog node, which verifies the
+	//     consumer CWT before forwarding arkavo_patreon).
+	// Leave false unless every decision caller satisfies one of those.
+	TrustMaterializedClaims bool `mapstructure:"trust_materialized_claims" json:"trust_materialized_claims"`
+	// TrustedIssuer, when set, is the issuer the materialized claim must
+	// have been minted by. On the verified-token path the iss claim is
+	// inside the signed token (non-forgeable), so this rejects a claim
+	// carried by a token from any other IdP. Empty = no issuer check
+	// (entityChain/claims path has no token iss to check; relies on the
+	// PEP trust boundary above).
+	TrustedIssuer string `mapstructure:"trusted_issuer" json:"trusted_issuer"`
 }
 
 // JWTConfig customizes which JWT claims the provider reads.
@@ -67,6 +91,8 @@ func (c Config) LogValue() slog.Value {
 		slog.String("creator_access_token", redact(c.CreatorAccessToken)),
 		slog.Any("campaign_ids", c.CampaignIDs),
 		slog.Bool("infer_unknown_as_free", c.InferUnknownAsFree),
+		slog.Bool("trust_materialized_claims", c.TrustMaterializedClaims),
+		slog.String("trusted_issuer", c.TrustedIssuer),
 	)
 }
 
@@ -244,9 +270,14 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtStri
 	// Preserve the materialized claim verbatim so the decision flow's
 	// second pass (ResolveEntities over the chain entities) re-derives the
 	// claims-passthrough resolution — including its direct entitlements —
-	// without ever consulting Patreon.
-	if raw, ok := claims["arkavo_patreon"].(map[string]interface{}); ok {
-		wrappedClaims["arkavo_patreon"] = raw
+	// without ever consulting Patreon. Only when trust is enabled AND the
+	// token's verified issuer matches TrustedIssuer (when configured): the
+	// iss is inside the signature-verified token, so this is a non-forgeable
+	// check on the token path.
+	if s.cfg.TrustMaterializedClaims && s.issuerTrusted(claims) {
+		if raw, ok := claims["arkavo_patreon"].(map[string]interface{}); ok {
+			wrappedClaims["arkavo_patreon"] = raw
+		}
 	}
 	subjectClaims, err := structpb.NewStruct(wrappedClaims)
 	if err != nil {
@@ -305,9 +336,13 @@ func liveResolution(mem *Membership, err error) (*resolution, error) {
 func (s *EntityResolutionService) resolveFromClaims(ctx context.Context, claims map[string]interface{}) (*resolution, error) {
 	// Claims-passthrough (SaaS multi-creator path): pre-materialized
 	// memberships from identity.arkavo.net need no Patreon access and emit
-	// campaign-qualified direct entitlements. See passthrough.go.
-	if claim := parseArkavoPatreon(claims); claim != nil {
-		return passthroughResolution(claim, s.cfg.entitlementsNamespace()), nil
+	// campaign-qualified direct entitlements. Gated on TrustMaterializedClaims
+	// (default off) — the claim is authoritative, so it is only honored when
+	// the operator has asserted the trust boundary. See passthrough.go.
+	if s.cfg.TrustMaterializedClaims {
+		if claim := parseArkavoPatreon(claims); claim != nil {
+			return passthroughResolution(claim, s.cfg.entitlementsNamespace()), nil
+		}
 	}
 	if tok, ok := claims[s.cfg.JWT.PatreonTokenClaim].(string); ok && tok != "" {
 		return liveResolution(s.client.ResolveSelf(ctx, tok))

--- a/service/entityresolution/patreon/v2/entity_resolution.go
+++ b/service/entityresolution/patreon/v2/entity_resolution.go
@@ -130,6 +130,12 @@ func RegisterPatreonERS(cfg config.ServiceConfig, log *logger.Logger) (*EntityRe
 	applyJWTDefaults(&c.JWT)
 	log.Debug("patreon entity resolution configuration", slog.Any("config", c))
 
+	if c.TrustMaterializedClaims && c.TrustedIssuer == "" {
+		log.Warn("patreon: trust_materialized_claims is enabled with no trusted_issuer — " +
+			"any signature-valid token from any IdP the platform accepts can inject " +
+			"arkavo_patreon membership claims; set trusted_issuer to pin the materializer")
+	}
+
 	client := NewClient(ClientOptions{
 		APIBase:            c.APIBase,
 		TokenURL:           c.TokenURL,
@@ -251,6 +257,17 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtStri
 		})
 	}
 
+	// Honor the materialized claim only through a trusted channel. Drop it
+	// up front when trust is off or the token's verified issuer is not the
+	// pinned one, so NEITHER the flattened patreon.* view (derived just
+	// below) NOR the re-preserved claim for the second pass can come from an
+	// untrusted issuer. The iss lives inside the signature-verified token,
+	// so the pin is non-forgeable on this path.
+	trusted := s.cfg.TrustMaterializedClaims && s.issuerTrusted(claims)
+	if !trusted {
+		delete(claims, "arkavo_patreon")
+	}
+
 	res, err := s.resolveFromClaims(ctx, claims)
 	switch {
 	case errors.Is(err, ErrMemberNotFound) && s.cfg.InferUnknownAsFree:
@@ -267,17 +284,11 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, jwtStri
 	wrappedClaims := map[string]interface{}{
 		"patreon": patreonStruct.AsMap(),
 	}
-	// Preserve the materialized claim verbatim so the decision flow's
-	// second pass (ResolveEntities over the chain entities) re-derives the
-	// claims-passthrough resolution — including its direct entitlements —
-	// without ever consulting Patreon. Only when trust is enabled AND the
-	// token's verified issuer matches TrustedIssuer (when configured): the
-	// iss is inside the signature-verified token, so this is a non-forgeable
-	// check on the token path.
-	if s.cfg.TrustMaterializedClaims && s.issuerTrusted(claims) {
-		if raw, ok := claims["arkavo_patreon"].(map[string]interface{}); ok {
-			wrappedClaims["arkavo_patreon"] = raw
-		}
+	// Preserve the (now trust-checked) materialized claim verbatim so the
+	// decision flow's second pass re-derives the passthrough — including its
+	// direct entitlements — without consulting Patreon.
+	if raw, ok := claims["arkavo_patreon"].(map[string]interface{}); ok {
+		wrappedClaims["arkavo_patreon"] = raw
 	}
 	subjectClaims, err := structpb.NewStruct(wrappedClaims)
 	if err != nil {

--- a/service/entityresolution/patreon/v2/passthrough.go
+++ b/service/entityresolution/patreon/v2/passthrough.go
@@ -119,7 +119,15 @@ func passthroughResolution(claim *arkavoPatreonClaim, namespace string) *resolut
 		entitlements = append(entitlements, fmt.Sprintf(
 			"https://%s/attr/%s/value/%s", namespace, campaignAttributeName, m.campaignID,
 		))
-		for _, slug := range m.tierSlugs {
+		for _, rawSlug := range m.tierSlugs {
+			// Enforce the FQN split invariant rather than trusting the
+			// materializer: slugify guarantees lowercase, no '_' and no
+			// spaces, so <campaign_id>_<tier_slug> splits unambiguously and
+			// matches the policy value form.
+			slug := slugify(rawSlug)
+			if slug == "" {
+				continue
+			}
 			// Flattened tier_slug is informational only in multi-creator
 			// mode; gating uses the campaign-qualified entitlements below.
 			if mem.TierSlug == tierFree {
@@ -147,4 +155,14 @@ func (c *Config) entitlementsNamespace() string {
 		return c.EntitlementsNamespace
 	}
 	return defaultEntitlementsNamespace
+}
+
+// issuerTrusted reports whether the verified token's issuer is acceptable
+// for materialized-claim passthrough. Empty TrustedIssuer = no check.
+func (s *EntityResolutionService) issuerTrusted(claims map[string]interface{}) bool {
+	if s.cfg.TrustedIssuer == "" {
+		return true
+	}
+	iss, _ := claims["iss"].(string)
+	return iss == s.cfg.TrustedIssuer
 }

--- a/service/entityresolution/patreon/v2/passthrough.go
+++ b/service/entityresolution/patreon/v2/passthrough.go
@@ -2,6 +2,7 @@ package patreon
 
 import (
 	"fmt"
+	"regexp"
 )
 
 // Claims-passthrough resolution: the SaaS multi-creator path.
@@ -34,6 +35,12 @@ const (
 	// campaign ids are numeric, so the first '_' splits unambiguously.
 	campaignTierSeparator = "_"
 )
+
+// numericCampaignID guards the FQN split invariant on the campaign side:
+// campaign ids must be numeric (Patreon's are), so they never contain the
+// '_' separator. A non-conforming id is skipped rather than producing an
+// ambiguous FQN.
+var numericCampaignID = regexp.MustCompile(`^[0-9]+$`)
 
 // resolution is a resolved entity: the flattened membership view (backing
 // the legacy .patreon.* selectors) plus any directly granted attribute
@@ -112,6 +119,11 @@ func passthroughResolution(claim *arkavoPatreonClaim, namespace string) *resolut
 			mem.Status = status
 		}
 		if status != statusActive {
+			continue
+		}
+		if !numericCampaignID.MatchString(m.campaignID) {
+			// Defensive: a non-numeric campaign id would break the
+			// <campaign_id>_<tier_slug> split. Skip it entirely.
 			continue
 		}
 		mem.Status = statusActive

--- a/service/entityresolution/patreon/v2/passthrough.go
+++ b/service/entityresolution/patreon/v2/passthrough.go
@@ -115,17 +115,23 @@ func passthroughResolution(claim *arkavoPatreonClaim, namespace string) *resolut
 	var entitlements []string
 	for _, m := range claim.memberships {
 		status := normalizeStatus(m.status)
-		if mem.Status != statusActive {
-			mem.Status = status
-		}
 		if status != statusActive {
+			// Surface a non-active status in the flattened view only while
+			// no active+valid campaign has been seen.
+			if mem.Status != statusActive {
+				mem.Status = status
+			}
 			continue
 		}
 		if !numericCampaignID.MatchString(m.campaignID) {
-			// Defensive: a non-numeric campaign id would break the
-			// <campaign_id>_<tier_slug> split. Skip it entirely.
+			// Active but malformed campaign id would break the
+			// <campaign_id>_<tier_slug> split. Skip it AND don't let it
+			// alone promote the flattened view to active — status and the
+			// entitlement set must stay consistent.
 			continue
 		}
+		// Active and valid: this campaign justifies both the active status
+		// and its entitlements.
 		mem.Status = statusActive
 		mem.CampaignIDs = append(mem.CampaignIDs, m.campaignID)
 		entitlements = append(entitlements, fmt.Sprintf(

--- a/service/entityresolution/patreon/v2/passthrough.go
+++ b/service/entityresolution/patreon/v2/passthrough.go
@@ -1,0 +1,150 @@
+package patreon
+
+import (
+	"fmt"
+)
+
+// Claims-passthrough resolution: the SaaS multi-creator path.
+//
+// identity.arkavo.net materializes every consumer's Patreon memberships into
+// the `arkavo_patreon` CWT claim at token mint, using the consumer's own
+// OAuth token — which sees every campaign they back. When those materialized
+// memberships arrive in an entity's claims (forwarded by an authenticated
+// PEP from a signature-verified token, or re-encoded by the platform's own
+// CWT verifier), this provider needs NO Patreon API access, NO per-creator
+// credentials, and NO per-creator policy:
+//
+//   - each ACTIVE membership emits direct entitlements (experimental
+//     synthetic-value support; only the attribute *definitions* below need
+//     to exist in policy):
+//     https://<ns>/attr/campaign/value/<campaign_id>
+//     https://<ns>/attr/campaign-tier/value/<campaign_id>_<tier_slug>
+//   - tier entitlements are campaign-qualified in the creator's OWN tier
+//     vocabulary — no cross-creator tier normalization, and no cross-tenant
+//     privilege leakage (a vip at creator A grants nothing at creator B).
+//
+// Content is tagged at protect time with the explicit value list for "this
+// tier and up" (the Creator app knows its own ladder), so no server ever
+// needs per-campaign hierarchy knowledge.
+const (
+	defaultEntitlementsNamespace = "patreon.arkavo.com"
+	campaignAttributeName        = "campaign"
+	campaignTierAttributeName    = "campaign-tier"
+	// Tier slugs never contain '_' (slugify maps separators to '-'), and
+	// campaign ids are numeric, so the first '_' splits unambiguously.
+	campaignTierSeparator = "_"
+)
+
+// resolution is a resolved entity: the flattened membership view (backing
+// the legacy .patreon.* selectors) plus any directly granted attribute
+// value FQNs derived from trusted, pre-materialized claims.
+type resolution struct {
+	mem          *Membership
+	entitlements []string
+}
+
+// materializedMembership is one campaign membership as materialized into
+// the arkavo_patreon claim by identity.arkavo.net.
+type materializedMembership struct {
+	campaignID string
+	status     string
+	tierSlugs  []string
+}
+
+// arkavoPatreonClaim is the parsed arkavo_patreon claim.
+type arkavoPatreonClaim struct {
+	role        string
+	userID      string
+	campaignID  string
+	memberships []materializedMembership
+}
+
+// parseArkavoPatreon extracts the materialized claim, tolerantly: absent or
+// malformed returns nil (callers fall back to live resolution paths).
+func parseArkavoPatreon(claims map[string]interface{}) *arkavoPatreonClaim {
+	raw, isMap := claims["arkavo_patreon"].(map[string]interface{})
+	if !isMap {
+		return nil
+	}
+	out := &arkavoPatreonClaim{}
+	out.role, _ = raw["role"].(string)
+	out.userID, _ = raw["patreon_user_id"].(string)
+	out.campaignID, _ = raw["campaign_id"].(string)
+
+	rawMemberships, _ := raw["memberships"].([]interface{})
+	for _, rm := range rawMemberships {
+		m, memIsMap := rm.(map[string]interface{})
+		if !memIsMap {
+			continue
+		}
+		mem := materializedMembership{}
+		mem.campaignID, _ = m["campaign_id"].(string)
+		mem.status, _ = m["patron_status"].(string)
+		if slugs, hasSlugs := m["tier_slugs"].([]interface{}); hasSlugs {
+			for _, s := range slugs {
+				if slug, isString := s.(string); isString && slug != "" {
+					mem.tierSlugs = append(mem.tierSlugs, slug)
+				}
+			}
+		}
+		if mem.campaignID != "" {
+			out.memberships = append(out.memberships, mem)
+		}
+	}
+	return out
+}
+
+// passthroughResolution converts a materialized claim into the flattened
+// membership view plus campaign-qualified direct entitlements. Only ACTIVE
+// memberships grant anything — declined/former patrons emit no entitlements
+// for that campaign.
+func passthroughResolution(claim *arkavoPatreonClaim, namespace string) *resolution {
+	mem := &Membership{
+		UserID:   claim.userID,
+		TierSlug: tierFree,
+		Status:   normalizeStatus(""),
+	}
+
+	var entitlements []string
+	for _, m := range claim.memberships {
+		status := normalizeStatus(m.status)
+		if mem.Status != statusActive {
+			mem.Status = status
+		}
+		if status != statusActive {
+			continue
+		}
+		mem.Status = statusActive
+		mem.CampaignIDs = append(mem.CampaignIDs, m.campaignID)
+		entitlements = append(entitlements, fmt.Sprintf(
+			"https://%s/attr/%s/value/%s", namespace, campaignAttributeName, m.campaignID,
+		))
+		for _, slug := range m.tierSlugs {
+			// Flattened tier_slug is informational only in multi-creator
+			// mode; gating uses the campaign-qualified entitlements below.
+			if mem.TierSlug == tierFree {
+				mem.TierSlug = slug
+			}
+			entitlements = append(entitlements, fmt.Sprintf(
+				"https://%s/attr/%s/value/%s%s%s",
+				namespace, campaignTierAttributeName, m.campaignID, campaignTierSeparator, slug,
+			))
+		}
+	}
+
+	// Creator role: surface the owned campaign like the live path does.
+	if claim.role == "creator" && claim.campaignID != "" {
+		mem.CampaignIDs = append(mem.CampaignIDs, claim.campaignID)
+	}
+
+	return &resolution{mem: mem, entitlements: entitlements}
+}
+
+// entitlementsNamespace returns the configured namespace for emitted
+// entitlement FQNs.
+func (c *Config) entitlementsNamespace() string {
+	if c.EntitlementsNamespace != "" {
+		return c.EntitlementsNamespace
+	}
+	return defaultEntitlementsNamespace
+}

--- a/service/entityresolution/patreon/v2/passthrough_test.go
+++ b/service/entityresolution/patreon/v2/passthrough_test.go
@@ -1,0 +1,183 @@
+package patreon
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/opentdf/platform/protocol/go/entity"
+	ersV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+)
+
+// forbiddenClient fails the test if any Patreon lookup is attempted — the
+// claims-passthrough path must never touch the API.
+type forbiddenClient struct{ t *testing.T }
+
+func (f *forbiddenClient) ResolveByUserID(context.Context, string) (*Membership, error) {
+	f.t.Fatal("passthrough must not call ResolveByUserID")
+	return nil, ErrMemberNotFound
+}
+
+func (f *forbiddenClient) ResolveByEmail(context.Context, string) (*Membership, error) {
+	f.t.Fatal("passthrough must not call ResolveByEmail")
+	return nil, ErrMemberNotFound
+}
+
+func (f *forbiddenClient) ResolveSelf(context.Context, string) (*Membership, error) {
+	f.t.Fatal("passthrough must not call ResolveSelf")
+	return nil, ErrMemberNotFound
+}
+
+func materializedClaims(t *testing.T) *anypb.Any {
+	t.Helper()
+	claims, err := structpb.NewStruct(map[string]interface{}{
+		"sub": "arkavo:u1",
+		"arkavo_patreon": map[string]interface{}{
+			"role":            "consumer",
+			"patreon_user_id": "p-77",
+			"memberships": []interface{}{
+				map[string]interface{}{
+					"campaign_id":   "11111111",
+					"patron_status": "active_patron",
+					"tier_slugs":    []interface{}{"gold-tier", "early-access"},
+				},
+				map[string]interface{}{
+					"campaign_id":   "22222222",
+					"patron_status": "former_patron",
+					"tier_slugs":    []interface{}{"vip"},
+				},
+				map[string]interface{}{
+					"campaign_id":   "33333333",
+					"patron_status": "active_patron",
+					// legacy materialization: no tier_slugs yet
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("claims struct: %v", err)
+	}
+	wrapped, err := anypb.New(claims)
+	if err != nil {
+		t.Fatalf("any: %v", err)
+	}
+	return wrapped
+}
+
+func TestPassthrough_EmitsCampaignQualifiedEntitlements(t *testing.T) {
+	svc := newSvc(t, Config{}, &forbiddenClient{t: t})
+
+	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "e0",
+			EntityType:  &entity.Entity_Claims{Claims: materializedClaims(t)},
+			Category:    entity.Entity_CATEGORY_SUBJECT,
+		}},
+	})
+	resp, err := svc.ResolveEntities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ResolveEntities: %v", err)
+	}
+	reprs := resp.Msg.GetEntityRepresentations()
+	if len(reprs) != 1 {
+		t.Fatalf("want 1 representation, got %d", len(reprs))
+	}
+
+	got := map[string]bool{}
+	for _, d := range reprs[0].GetDirectEntitlements() {
+		got[d.GetAttributeValueFqn()] = true
+		if len(d.GetActions()) != 1 || d.GetActions()[0] != "read" {
+			t.Errorf("entitlement %s actions = %v, want [read]", d.GetAttributeValueFqn(), d.GetActions())
+		}
+	}
+
+	want := []string{
+		// active membership: campaign + campaign-qualified tiers in the
+		// creator's own vocabulary
+		"https://patreon.arkavo.com/attr/campaign/value/11111111",
+		"https://patreon.arkavo.com/attr/campaign-tier/value/11111111_gold-tier",
+		"https://patreon.arkavo.com/attr/campaign-tier/value/11111111_early-access",
+		// active membership without materialized slugs: campaign only
+		"https://patreon.arkavo.com/attr/campaign/value/33333333",
+	}
+	for _, fqn := range want {
+		if !got[fqn] {
+			t.Errorf("missing entitlement %s (got %v)", fqn, got)
+		}
+	}
+	// Former patron at 22222222 must grant NOTHING — no cross-tenant or
+	// lapsed-membership leakage.
+	for fqn := range got {
+		if len(got) > 0 && (fqn == "https://patreon.arkavo.com/attr/campaign/value/22222222" ||
+			fqn == "https://patreon.arkavo.com/attr/campaign-tier/value/22222222_vip") {
+			t.Errorf("former membership leaked entitlement: %s", fqn)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("entitlement count = %d, want %d: %v", len(got), len(want), got)
+	}
+
+	// The flattened .patreon.* view still surfaces active campaigns.
+	props := reprs[0].GetAdditionalProps()[0].AsMap()
+	patreon, ok := props["patreon"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("patreon claims missing: %v", props)
+	}
+	if patreon["status"] != "active" {
+		t.Errorf("status = %v, want active", patreon["status"])
+	}
+}
+
+func TestPassthrough_AllFormerMembershipsGrantNothing(t *testing.T) {
+	svc := newSvc(t, Config{}, &forbiddenClient{t: t})
+	claims, _ := structpb.NewStruct(map[string]interface{}{
+		"arkavo_patreon": map[string]interface{}{
+			"role":            "consumer",
+			"patreon_user_id": "p-9",
+			"memberships": []interface{}{
+				map[string]interface{}{
+					"campaign_id":   "44444444",
+					"patron_status": "declined_patron",
+					"tier_slugs":    []interface{}{"gold"},
+				},
+			},
+		},
+	})
+	wrapped, _ := anypb.New(claims)
+	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "e0",
+			EntityType:  &entity.Entity_Claims{Claims: wrapped},
+		}},
+	})
+	resp, err := svc.ResolveEntities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ResolveEntities: %v", err)
+	}
+	if n := len(resp.Msg.GetEntityRepresentations()[0].GetDirectEntitlements()); n != 0 {
+		t.Errorf("declined patron got %d entitlements, want 0", n)
+	}
+}
+
+func TestPassthrough_CustomNamespace(t *testing.T) {
+	res := passthroughResolution(&arkavoPatreonClaim{
+		memberships: []materializedMembership{{
+			campaignID: "55",
+			status:     "active_patron",
+			tierSlugs:  []string{"basic"},
+		}},
+	}, "members.example.com")
+	want := "https://members.example.com/attr/campaign-tier/value/55_basic"
+	found := false
+	for _, e := range res.entitlements {
+		if e == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("custom namespace entitlement missing: %v", res.entitlements)
+	}
+}

--- a/service/entityresolution/patreon/v2/passthrough_test.go
+++ b/service/entityresolution/patreon/v2/passthrough_test.go
@@ -68,7 +68,7 @@ func materializedClaims(t *testing.T) *anypb.Any {
 }
 
 func TestPassthrough_EmitsCampaignQualifiedEntitlements(t *testing.T) {
-	svc := newSvc(t, Config{}, &forbiddenClient{t: t})
+	svc := newSvc(t, Config{TrustMaterializedClaims: true}, &forbiddenClient{t: t})
 
 	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
 		Entities: []*entity.Entity{{
@@ -132,7 +132,7 @@ func TestPassthrough_EmitsCampaignQualifiedEntitlements(t *testing.T) {
 }
 
 func TestPassthrough_AllFormerMembershipsGrantNothing(t *testing.T) {
-	svc := newSvc(t, Config{}, &forbiddenClient{t: t})
+	svc := newSvc(t, Config{TrustMaterializedClaims: true}, &forbiddenClient{t: t})
 	claims, _ := structpb.NewStruct(map[string]interface{}{
 		"arkavo_patreon": map[string]interface{}{
 			"role":            "consumer",
@@ -180,4 +180,56 @@ func TestPassthrough_CustomNamespace(t *testing.T) {
 	if !found {
 		t.Errorf("custom namespace entitlement missing: %v", res.entitlements)
 	}
+}
+
+func TestPassthrough_SlugifiesTierToEnforceSplitInvariant(t *testing.T) {
+	res := passthroughResolution(&arkavoPatreonClaim{
+		memberships: []materializedMembership{{
+			campaignID: "77",
+			status:     "active_patron",
+			tierSlugs:  []string{"Gold Tier_Plus"},
+		}},
+	}, defaultEntitlementsNamespace)
+	want := "https://patreon.arkavo.com/attr/campaign-tier/value/77_gold-tier-plus"
+	found := false
+	for _, e := range res.entitlements {
+		if e == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("slug not normalized; got %v", res.entitlements)
+	}
+}
+
+func TestPassthrough_DisabledByDefault(t *testing.T) {
+	svc := newSvc(t, Config{InferUnknownAsFree: true}, freeFallbackClient{})
+	req := connect.NewRequest(&ersV2.ResolveEntitiesRequest{
+		Entities: []*entity.Entity{{
+			EphemeralId: "e0",
+			EntityType:  &entity.Entity_Claims{Claims: materializedClaims(t)},
+		}},
+	})
+	resp, err := svc.ResolveEntities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ResolveEntities: %v", err)
+	}
+	if n := len(resp.Msg.GetEntityRepresentations()[0].GetDirectEntitlements()); n != 0 {
+		t.Errorf("trust disabled but got %d entitlements — claim was honored ungated", n)
+	}
+}
+
+// freeFallbackClient always misses, exercising the InferUnknownAsFree path.
+type freeFallbackClient struct{}
+
+func (freeFallbackClient) ResolveByUserID(context.Context, string) (*Membership, error) {
+	return nil, ErrMemberNotFound
+}
+
+func (freeFallbackClient) ResolveByEmail(context.Context, string) (*Membership, error) {
+	return nil, ErrMemberNotFound
+}
+
+func (freeFallbackClient) ResolveSelf(context.Context, string) (*Membership, error) {
+	return nil, ErrMemberNotFound
 }

--- a/service/entityresolution/patreon/v2/passthrough_test.go
+++ b/service/entityresolution/patreon/v2/passthrough_test.go
@@ -2,15 +2,35 @@ package patreon
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/opentdf/platform/protocol/go/entity"
 	ersV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
 )
+
+// buildJWT builds an UNSIGNED JWT with the given claims — entitiesFromToken
+// parses without verification (the platform authn layer verifies upstream),
+// so an unsigned token exercises the claim-handling logic directly.
+func buildJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	tok := jwt.New()
+	for k, v := range claims {
+		if err := tok.Set(k, v); err != nil {
+			t.Fatalf("set claim %s: %v", k, err)
+		}
+	}
+	b, err := jwt.NewSerializer().Serialize(tok)
+	if err != nil {
+		t.Fatalf("serialize jwt: %v", err)
+	}
+	return string(b)
+}
 
 // forbiddenClient fails the test if any Patreon lookup is attempted — the
 // claims-passthrough path must never touch the API.
@@ -216,6 +236,81 @@ func TestPassthrough_DisabledByDefault(t *testing.T) {
 	}
 	if n := len(resp.Msg.GetEntityRepresentations()[0].GetDirectEntitlements()); n != 0 {
 		t.Errorf("trust disabled but got %d entitlements — claim was honored ungated", n)
+	}
+}
+
+func TestPassthrough_UntrustedIssuerLeaksNothingViaToken(t *testing.T) {
+	// A signature-valid token from a NON-pinned issuer must not derive the
+	// flattened patreon.* view OR direct entitlements from arkavo_patreon.
+	// Build a JWT carrying iss=evil + a forged arkavo_patreon, run it
+	// through CreateEntityChainsFromTokens (the token path), and assert the
+	// subject entity reflects no active membership and no entitlements.
+	svc := newSvc(t, Config{
+		TrustMaterializedClaims: true,
+		TrustedIssuer:           "https://identity.arkavo.net",
+		InferUnknownAsFree:      true,
+	}, freeFallbackClient{})
+
+	forged := buildJWT(t, map[string]interface{}{
+		"iss": "https://evil.example.com",
+		"sub": "attacker",
+		"arkavo_patreon": map[string]interface{}{
+			"role":            "consumer",
+			"patreon_user_id": "p-evil",
+			"memberships": []interface{}{map[string]interface{}{
+				"campaign_id":   "11111111",
+				"patron_status": "active_patron",
+				"tier_slugs":    []interface{}{"gold-tier"},
+			}},
+		},
+	})
+	resp, err := svc.CreateEntityChainsFromTokens(context.Background(),
+		connect.NewRequest(&ersV2.CreateEntityChainsFromTokensRequest{
+			Tokens: []*entity.Token{{EphemeralId: "t0", Jwt: forged}},
+		}))
+	if err != nil {
+		t.Fatalf("CreateEntityChainsFromTokens: %v", err)
+	}
+	// Find the subject entity's claims; assert no active patreon status and
+	// no preserved arkavo_patreon (so the second pass grants nothing).
+	var subject *entity.Entity
+	for _, e := range resp.Msg.GetEntityChains()[0].GetEntities() {
+		if e.GetCategory() == entity.Entity_CATEGORY_SUBJECT {
+			subject = e
+		}
+	}
+	if subject == nil {
+		t.Fatal("no subject entity")
+	}
+	var st structpb.Struct
+	if err := subject.GetClaims().UnmarshalTo(&st); err != nil {
+		t.Fatalf("unpack: %v", err)
+	}
+	m := st.AsMap()
+	if _, present := m["arkavo_patreon"]; present {
+		t.Error("untrusted issuer: arkavo_patreon was preserved for second pass")
+	}
+	patreon, _ := m["patreon"].(map[string]interface{})
+	if patreon["status"] == "active" {
+		t.Errorf("untrusted issuer leaked active status: %v", patreon)
+	}
+}
+
+func TestPassthrough_NonNumericCampaignIDSkipped(t *testing.T) {
+	res := passthroughResolution(&arkavoPatreonClaim{
+		memberships: []materializedMembership{
+			{campaignID: "good_123", status: "active_patron", tierSlugs: []string{"gold"}},
+			{campaignID: "12345678", status: "active_patron", tierSlugs: []string{"gold"}},
+		},
+	}, defaultEntitlementsNamespace)
+	for _, e := range res.entitlements {
+		if strings.Contains(e, "good_123") {
+			t.Errorf("non-numeric campaign id produced an FQN: %s", e)
+		}
+	}
+	// The valid numeric campaign still produced entitlements.
+	if len(res.entitlements) == 0 {
+		t.Error("valid campaign produced no entitlements")
 	}
 }
 

--- a/service/entityresolution/patreon/v2/passthrough_test.go
+++ b/service/entityresolution/patreon/v2/passthrough_test.go
@@ -314,6 +314,39 @@ func TestPassthrough_NonNumericCampaignIDSkipped(t *testing.T) {
 	}
 }
 
+func TestPassthrough_MalformedActiveCampaignDoesNotFlipStatus(t *testing.T) {
+	// An ACTIVE membership whose only campaign is malformed must not leave
+	// the flattened view reporting status=active with zero entitlements.
+	res := passthroughResolution(&arkavoPatreonClaim{
+		memberships: []materializedMembership{
+			{campaignID: "bad_id", status: "active_patron", tierSlugs: []string{"gold"}},
+		},
+	}, defaultEntitlementsNamespace)
+	if len(res.entitlements) != 0 {
+		t.Errorf("malformed campaign emitted entitlements: %v", res.entitlements)
+	}
+	if res.mem.Status == statusActive {
+		t.Errorf("flattened status is active but no campaign backs it: %v", res.mem)
+	}
+
+	// A valid active campaign alongside a malformed one: status active,
+	// only the valid campaign's entitlements.
+	res = passthroughResolution(&arkavoPatreonClaim{
+		memberships: []materializedMembership{
+			{campaignID: "bad_id", status: "active_patron", tierSlugs: []string{"gold"}},
+			{campaignID: "99", status: "active_patron", tierSlugs: []string{"silver"}},
+		},
+	}, defaultEntitlementsNamespace)
+	if res.mem.Status != statusActive {
+		t.Errorf("valid active campaign should set status active: %v", res.mem)
+	}
+	for _, e := range res.entitlements {
+		if strings.Contains(e, "bad_id") {
+			t.Errorf("malformed campaign leaked entitlement: %s", e)
+		}
+	}
+}
+
 // freeFallbackClient always misses, exercising the InferUnknownAsFree path.
 type freeFallbackClient struct{}
 


### PR DESCRIPTION
The multi-creator SaaS redesign of Patreon entitlements: **`creator_access_token` and `campaign_ids` stop being requirements** — Patreon is called exactly once per consumer per cache-TTL, at identity.arkavo.net, with the consumer's own token. Decisions consume the signed claim.

## How it works

When an entity's claims carry the `arkavo_patreon` materialization (forwarded by an authenticated PEP like the catalog node, or arriving via the platform CWT verifier's unsigned-JWT re-encoding on the KAS path), the ERS short-circuits — zero Patreon API calls — and emits **direct entitlements** per ACTIVE membership:

```
https://patreon.arkavo.com/attr/campaign/value/<campaign_id>
https://patreon.arkavo.com/attr/campaign-tier/value/<campaign_id>_<tier_slug>
```

- **Creator's own tier vocabulary**, campaign-qualified — zero onboarding config, no cross-creator tier normalization.
- **Dynamic values** via the fork's synthetic-value support (`allow_direct_entitlements`): only the new values-empty `campaign-tier` definition exists in policy. Onboarding a creator = nothing. (This is the capability upstream calls dynamic attribute values and hasn't shipped.)
- **Fixes a cross-tenant privilege leak**: the flattened `tier_slug` model let vip-at-creator-A satisfy creator-B's vip gate. Campaign-qualified entitlements close the class; declined/former memberships grant nothing.
- "This tier and up" = explicit anyOf value list applied at protect time by the Creator app, which knows its own ladder.

## Live verification

Ran against a local platform (`allow_direct_entitlements: true`, **no Patreon credentials configured at all**) with a chain entity carrying materialized memberships — every decision correct, every value synthetic:

| Resource | Decision |
|---|---|
| `campaign-tier/11111111_gold-tier` (their tier) | PERMIT |
| `campaign-tier/11111111_platinum` (higher tier) | DENY |
| `campaign-tier/22222222_gold-tier` (same name, other campaign) | DENY |
| `campaign/22222222` (lapsed) | DENY |
| `campaign/11111111` (active) | PERMIT |

## Follow-ups (separate repos)

- authnz-rs: materialize `tier_slugs` per membership into `arkavo_patreon` (until then, passthrough grants campaign-level entitlements only — graceful).
- tdf-iroh-s3: forward the verified memberships in chain claims.
- Production config: `allow_direct_entitlements: true` + the `campaign-tier` definition (both staged in the prod files on the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)