### PR TITLE
feat(ci): call IdP conformance suite on auth-surface PRs

### DIFF
--- a/.github/workflows/idp-conformance.yml
+++ b/.github/workflows/idp-conformance.yml
@@ -1,0 +1,37 @@
+# Runs the black-box IdP conformance suite (arkavo-org/opentdf-tests) on PRs
+# that touch the platform's auth surface: token verification and JWKS
+# handling, DPoP, entity resolution, KAS rewrap, well-known configuration,
+# and the SDK auth client. The suite itself is provider-agnostic; this caller
+# runs the always-available keycloak tier against the PR's platform code.
+# External-provider tiers (auth0, okta, ...) run nightly in the tests repo.
+name: IdP Conformance
+
+on:
+  pull_request:
+    paths:
+      - "service/internal/auth/**"
+      - "service/pkg/auth/**"
+      - "service/entityresolution/**"
+      - "service/kas/**"
+      - "service/wellknownconfiguration/**"
+      - "sdk/auth/**"
+      - "protocol/go/**"
+      - ".github/workflows/idp-conformance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  idp-conformance:
+    name: IdP conformance (keycloak tier)
+    uses: arkavo-org/opentdf-tests/.github/workflows/idp-conformance.yml@main
+    with:
+      providers: keycloak
+      # Exercise the PR's platform code: the reusable workflow checks the
+      # platform out at this ref and runs the suite against it.
+      platform-ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref_name }}


### PR DESCRIPTION
Implements the PR-trigger half of [discussion #3327](https://github.com/orgs/opentdf/discussions/3327) (black-box IdP conformance tests): when a PR touches the platform's auth surface, run the provider-agnostic conformance suite against the PR's platform code.

## What this adds

One workflow, `idp-conformance.yml`, that calls the reusable suite in [arkavo-org/opentdf-tests](https://github.com/arkavo-org/opentdf-tests) (`idp-conformance.yml@main`) on PRs path-filtered to:

```
service/internal/auth/**      # the authN/authZ middleware (authn.go, discovery, token_verifier, dpop)
service/pkg/auth/**           # auth context propagation
service/entityresolution/**   # ERS (claims / keycloak / multi-strategy)
service/kas/**                # rewrap
service/wellknownconfiguration/**
sdk/auth/**                   # SDK token acquisition (oauth, DPoP assertion)
protocol/go/**                # generated connect routes
```

The suite runs its always-available keycloak tier against a platform built from this PR (`platform-ref: refs/pull/<n>/head`) and checks the discussion's list: OIDC discovery, JWKS, client-credentials token acceptance, audience/issuer validation, DPoP proof round-trip, ERS entity resolution, negative cases (tampered signature, unknown signer), and an end-to-end TDF encrypt → KAS rewrap → decrypt.

Note on the filter list: the discussion proposed `service/pkg/auth/**`, but the middleware actually lives in `service/internal/auth/**` — `service/pkg/auth` is only context propagation. Both are included.

## Behavior and cost

- Only auth-touching PRs pay for it (platform build + suite ≈ 10 min); everything else never triggers the workflow.
- It complements, not replaces, the existing Keycloak-based integration tests.
- External-provider tiers (Auth0 is onboarded; Okta/Entra/Cognito/Google templated) run on the nightly schedule in opentdf-tests; this caller runs the keycloak tier, which needs no secrets.

The suite itself is merged ([arkavo-org/opentdf-tests#6](https://github.com/arkavo-org/opentdf-tests/pull/6)), so the reusable workflow this references (`@main`) exists.

(Supersedes arkavo-org/platform#1, moved to the hard fork.)
