### PR TITLE
feat(auth): drop arkavo_ prefix from OIDC discovery extensions

### DIFF
--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -114,17 +114,17 @@ func (s *AuthSuite) SetupTest() {
 	s.kid = kid
 	keySetCBOR := coseKeySetFromPub(s.T(), &priv.PublicKey, kid)
 
-	// Fake IdP — serves OIDC discovery (with the arkavo_cose_keys_uri
-	// extension so NewAuthenticator can find the key set) and the COSE Key
-	// Set itself. JWKS is still served (empty) so anything that consults the
-	// discovery doc and follows jwks_uri sees a well-formed response, even
-	// though the platform now verifies bearers as CWTs.
+	// Fake IdP — serves OIDC discovery (with the cose_keys_uri extension so
+	// NewAuthenticator can find the key set) and the COSE Key Set itself.
+	// JWKS is still served (empty) so anything that consults the discovery
+	// doc and follows jwks_uri sees a well-formed response, even though the
+	// platform now verifies bearers as CWTs.
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/.well-known/openid-configuration":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w,
-				`{"issuer":%q,"jwks_uri":%q,"arkavo_cose_keys_uri":%q}`,
+				`{"issuer":%q,"jwks_uri":%q,"cose_keys_uri":%q}`,
 				s.server.URL, s.server.URL+"/jwks", s.server.URL+"/cose-keys")
 		case "/cose-keys":
 			w.Header().Set("Content-Type", "application/cose-key-set+cbor")

--- a/service/internal/auth/discovery.go
+++ b/service/internal/auth/discovery.go
@@ -18,7 +18,7 @@ const (
 
 // OIDCConfiguration holds the openid configuration for the issuer.
 // Currently only required fields are included (https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata),
-// plus the Arkavo extension that advertises a COSE Key Set for CWT verifiers.
+// plus two CWT-related extension fields advertised by Arkavo-compatible IdPs.
 type OIDCConfiguration struct {
 	Issuer                           string   `json:"issuer"`
 	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
@@ -28,13 +28,17 @@ type OIDCConfiguration struct {
 	ResponseTypesSupported           []string `json:"response_types_supported"`
 	SubjectTypesSupported            []string `json:"subject_types_supported"`
 	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
-	RequireRequestURIRegistration    bool     `json:"require_request_uri_registration"`
+
+	// AccessTokenFormat is the IANA media type of the issuer's access tokens.
+	// Arkavo IdPs set this to "application/cwt" to signal that bearer tokens
+	// are CWTs (RFC 8392) rather than JWTs. Extension field — not part of the
+	// OIDC Discovery spec.
+	AccessTokenFormat string `json:"access_token_format,omitempty"`
 
 	// CoseKeysURI is the URL of the COSE Key Set used to verify CWT bearer
-	// tokens (RFC 8392 / RFC 9052). Not part of the OIDC Discovery spec —
-	// advertised by Arkavo-compatible IdPs (authnz-rs) under the custom
-	// "arkavo_cose_keys_uri" field. Empty when the IdP does not issue CWTs.
-	CoseKeysURI string `json:"arkavo_cose_keys_uri,omitempty"`
+	// tokens (RFC 8392 / RFC 9052). Extension field — not part of the OIDC
+	// Discovery spec. Empty when the IdP does not issue CWTs.
+	CoseKeysURI string `json:"cose_keys_uri,omitempty"`
 }
 
 // DiscoverOPENIDConfiguration discovers the openid configuration for the issuer provided

--- a/service/internal/auth/token_verifier.go
+++ b/service/internal/auth/token_verifier.go
@@ -3,7 +3,7 @@
 // The platform accepts CWT bearer tokens (RFC 8392, COSE_Sign1, ES256) issued
 // by an IdP that publishes a COSE Key Set. The IdP advertises that key-set
 // URL in its OIDC Discovery document under the custom field
-// `arkavo_cose_keys_uri`; we re-use the same OIDC issuer/JWKS infrastructure
+// `cose_keys_uri`; we re-use the same OIDC issuer/JWKS infrastructure
 // for everything else (issuer alignment, audience matching, well-known
 // registration) but route the actual signature verification through
 // CWTVerifier rather than jwx.
@@ -50,7 +50,7 @@ func newTokenVerifier(ctx context.Context, cfg AuthNConfig, log *logger.Logger) 
 	}
 	if oidcConfig.CoseKeysURI == "" {
 		return nil, nil, cfg, fmt.Errorf(
-			"idp %s does not advertise arkavo_cose_keys_uri in its discovery document; "+
+			"idp %s does not advertise cose_keys_uri in its discovery document; "+
 				"the platform requires CWT bearer tokens (see service/internal/auth/cwt_verifier.go)",
 			cfg.Issuer,
 		)

--- a/service/pkg/server/start_test.go
+++ b/service/pkg/server/start_test.go
@@ -108,13 +108,13 @@ func mockKeycloakServer() *httptest.Server {
 			var resp string
 			switch req.URL.Path {
 			case "/.well-known/openid-configuration":
-				// arkavo_cose_keys_uri is required for NewCWTVerifier to
-				// construct successfully (an empty value short-circuits the
-				// constructor with an error). The URL itself doesn't need
-				// to resolve — the eager key-set fetch is best-effort and
-				// just logs a warning on failure (cwt_verifier.go:140-145) —
-				// which is fine for these config-error tests that don't
-				// actually verify any tokens.
+				// cose_keys_uri is required for NewCWTVerifier to construct
+				// successfully (an empty value short-circuits the constructor
+				// with an error). The URL itself doesn't need to resolve —
+				// the eager key-set fetch is best-effort and just logs a
+				// warning on failure (cwt_verifier.go:140-145) — which is
+				// fine for these config-error tests that don't actually
+				// verify any tokens.
 				resp = `{
 					"issuer":	"https://example.com",
 					"authorization_endpoint":	"https://example.com/oauth2/v1/authorize",
@@ -122,7 +122,7 @@ func mockKeycloakServer() *httptest.Server {
 					"userinfo_endpoint": "https://example.com/oauth2/v1/userinfo",
 					"registration_endpoint": "https://example.com/oauth2/v1/clients",
 					"jwks_uri": "` + discoveryURL + `/oauth2/v1/keys",
-					"arkavo_cose_keys_uri": "` + discoveryURL + `/cose-keys"
+					"cose_keys_uri": "` + discoveryURL + `/cose-keys"
 				}`
 			case "/oauth2/v1/keys":
 				resp = `{


### PR DESCRIPTION
Preserving local work that existed only on this machine (commits dated 2026-05-24 to 05-27). Opened as a **draft** for triage — not proposed for merge as-is.

**1 commit(s)** ahead of `main`:

- \`33499ad0\` feat(auth): drop arkavo_ prefix from OIDC discovery extensions

Targets `arkavo-org/opentdf-platform` deliberately, **not** the `opentdf/platform` upstream this repo is forked from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXZEShmKDicGgfd81J2JaS