### PR TITLE
feat(ers): arkavo claims-passthrough mode with NPE entities and class ceilings

### DIFF
--- a/examples/config/opentdf-arkavo-local-test.yaml
+++ b/examples/config/opentdf-arkavo-local-test.yaml
@@ -1,0 +1,38 @@
+# Local contract test: arkavo ERS + arkavo policy snapshot, no Postgres, no KAS.
+#
+#   go run ./service start --config-file ../examples/config/opentdf-arkavo-local-test.yaml
+#
+# Auth is enabled and pinned to a local authnz-rs (cose-keys at the issuer).
+mode: core,entityresolution,-policy,-kas
+
+logger:
+  level: debug
+  type: text
+  output: stderr
+
+server:
+  port: 8080
+  auth:
+    enabled: true
+    enforceDPoP: false
+    issuer: http://127.0.0.1:8081
+    audience: https://platform.test
+    policy:
+      client_id_claim: arkavo_account_id
+      groups_claim: arkavo_roles
+      map:
+        standard: service-account
+
+services:
+  authorization:
+    policy_file: ./examples/config/policy.arkavo.yaml
+    allow_direct_entitlements: true
+  entityresolution:
+    mode: arkavo
+    trust_materialized_claims: true
+    trusted_issuer: http://127.0.0.1:8081
+    direct_entitlement_actions: [read]
+    device_class_ceilings:
+      unverified: ["https://arkavo.ai/attr/classification/value/internal"]
+      managed:    ["https://arkavo.ai/attr/classification/value/confidential"]
+      attested:   ["https://arkavo.ai/attr/classification/value/restricted"]

--- a/examples/config/policy.arkavo.yaml
+++ b/examples/config/policy.arkavo.yaml
@@ -1,0 +1,54 @@
+# arkavo identity-plane policy snapshot: vocabulary only. Entitlements are
+# carried in authnz-rs CWTs (arkavo_entitlements) and asserted by the
+# `arkavo` ERS mode as direct entitlements — there are no subject mappings.
+#
+#   services:
+#     authorization:
+#       policy_file: ./examples/config/policy.arkavo.yaml
+#       allow_direct_entitlements: true
+#     entityresolution:
+#       mode: arkavo
+
+namespaces:
+  - name: arkavo.ai
+
+attributes:
+  # TDF operations a subject may perform. Values are attribute values, NOT
+  # action names — the action on every direct entitlement is `read`.
+  - namespace: arkavo.ai
+    name: tdf
+    rule: anyOf
+    values:
+      - value: create
+      - value: decrypt
+
+  # Agent delegation vocabulary (authnz-rs HUMAN_DELEGABLE / stored entitlements).
+  - namespace: arkavo.ai
+    name: action
+    rule: anyOf
+    values:
+      - value: read
+      - value: write
+      - value: execute
+      - value: delegate
+      - value: admin
+
+  - namespace: arkavo.ai
+    name: mesh
+    rule: anyOf
+    values:
+      - value: orchestrator
+      - value: worker
+
+  # Data classification. HIERARCHY: the PDP ranks by index, LOWEST INDEX IS
+  # HIGHEST RANK — keep this order. Device class ceilings grant one of these.
+  - namespace: arkavo.ai
+    name: classification
+    rule: hierarchy
+    values:
+      - value: restricted
+      - value: confidential
+      - value: internal
+      - value: public
+
+subject_mappings: []

--- a/service/README.md
+++ b/service/README.md
@@ -59,6 +59,20 @@ to a namespace.
 - Key Access (KAS) - Controls access to TDF protected content.
 - Policy - Manages the policy for the TDF platform.
 
+## Authentication Headers
+
+In addition to the standard `Authorization: Bearer <token>` (or `DPoP <token>`)
+header, the platform recognizes:
+
+- `X-Actor-Token` - A second, separately verified access token identifying the
+  effective actor making the request on behalf of the bearer token's subject
+  (for example, an agent acting for a person). The platform enforces that the
+  actor token's subject either equals the bearer token's own subject
+  (self-actation) or appears in the bearer token's `act` claim (a list of
+  `{"sub": "..."}` entries); an actor token that verifies but carries no
+  subject is rejected. The header is optional — omitting it leaves
+  authentication behavior unchanged.
+
 ## Development
 
 ### Generation

--- a/service/entityresolution/README.md
+++ b/service/entityresolution/README.md
@@ -34,6 +34,20 @@ ERS enables the OpenTDF platform to:
 - **Failure Strategies**: `fail-fast` (default) for strict error handling, `continue` for resilient failover
 - **Use Case**: Organizations with heterogeneous identity systems, complex authorization requirements
 
+### Arkavo Entity Resolution Service (STABLE)
+- **Status**: ✅ **Stable**
+- **Location**: [`./arkavo/`](./arkavo/)
+- **Backends**: authnz-rs CWT/JWT claims passthrough with NPE entities and direct entitlements
+- **Features**: Token validation, direct entitlements, device class ceilings, no external dependencies
+- **Use Case**: Arkavo ecosystem identity resolution with distributed authorization
+
+### Patreon Entity Resolution Service (STABLE)
+- **Status**: ✅ **Stable**
+- **Location**: [`./patreon/`](./patreon/)
+- **Backends**: Patreon membership materialized via authnz-rs claims
+- **Features**: Campaign-qualified entitlements, tier-based access, no per-creator config
+- **Use Case**: Creator economy platforms with Patreon integrations
+
 ## Quick Start
 
 ### 1. Choose Your Implementation
@@ -51,6 +65,10 @@ services:
     mode: keycloak  # Keycloak identity provider
     # OR (V2 only)
     mode: multi-strategy  # LDAP, SQL, and JWT Claims with intelligent routing
+    # OR
+    mode: arkavo    # Arkavo identity-plane with direct entitlements
+    # OR
+    mode: patreon   # Patreon membership materialized via authnz-rs claims
     # Implementation-specific configuration
 ```
 

--- a/service/entityresolution/README.md
+++ b/service/entityresolution/README.md
@@ -55,6 +55,8 @@ Select the ERS implementation that matches your identity backend:
 - Use **Claims ERS** for JWT-based authentication systems
 - Use **Keycloak ERS** for Keycloak identity provider integration
 - Use **Multi-Strategy ERS** for LDAP, SQL databases, and multiple backends with intelligent routing
+- Use **Arkavo ERS** for authnz-rs CWT/JWT claims passthrough with direct entitlements
+- Use **Patreon ERS** for Patreon membership materialized via authnz-rs claims
 
 ### 2. Configure Your Service
 ```yaml

--- a/service/entityresolution/arkavo/v2/README.md
+++ b/service/entityresolution/arkavo/v2/README.md
@@ -68,23 +68,63 @@ values to be honored.
 ## Trust Model
 
 Arkavo entitlements are signed upstream at authnz-rs and verified by the
-platform's token validation layer before reaching the ERS. The ERS trusts
-only tokens from the `trusted_issuer` pin — all other issuers are rejected.
+platform's token validation layer before reaching the ERS. The provider uses
+a two-path resolution model with different trust semantics on each path,
+unified by the `arkavo_trusted` marker and the `trust_materialized_claims`
+master switch.
+
+### The `arkavo_trusted` Marker
+
+When `CreateEntityChainsFromTokens` processes a token, it checks the issuer
+against `trusted_issuer` (if `trust_materialized_claims` is on). If the check
+passes, it stamps `arkavo_trusted: true` onto the SUBJECT entity's claims,
+along with `arkavo_entitlements` and the raw `arkavo_npe` data. This marker
+carries the issuer decision forward into the claims-entity path.
+
+### Two-Path Resolution
+
+**Token path** (`CreateEntityChainsFromTokens`):
+- Token signature is verified by platform authn middleware (before reaching ERS)
+- If `trust_materialized_claims` is on: issuer comparison against `trusted_issuer` is enforced here
+- If check passes: `arkavo_trusted: true` marker is set
+- If check fails or `trust_materialized_claims` is off: no marker, no entitlements
+
+**Claims-entity path** (`ResolveEntities`):
+- Caller supplies an Entity_Claims payload (may have originated elsewhere)
+- The issuer comparison is NOT redone on this path — only the `arkavo_trusted` marker is checked
+- If `trust_materialized_claims` is on AND `claims["arkavo_trusted"] == true`: direct entitlements are emitted
+- If either condition is false: no entitlements
+
+Critically: a caller who can construct or forward a claims entity with a forged
+`arkavo_trusted: true` marker will bypass the `trusted_issuer` pin on the
+claims-entity path. The operator's protection on that path is **the PEP
+boundary** — `ResolveEntities` must be reachable only through a trusted
+decision layer. The `trust_materialized_claims` flag is the master switch
+that gates entitlements on both paths, but only the token path can enforce
+the issuer pin; the marker is what carries that decision to the second pass.
+
+When `trust_materialized_claims: false`, entitlements are disabled on both paths
+entirely — no marker check avoids this setting.
 
 ### Entity Resolution Flow
 
 1. **Token arrives at ERS**: JWT (JOSE) or CWT (COSE), signature already verified
    by the platform's authn middleware.
-2. **Issuer check**: If `trust_materialized_claims` is on, verify that the token
-   comes from the `trusted_issuer`.
-3. **Claims extraction**: Extract `arkavo_entitlements`, `arkavo_account_id`
-   (client ID), and other claims.
-4. **Entity synthesis**: Create a SUBJECT entity carrying the entitlements claim
-   and a marker indicating it was trust-gated (PEP boundary).
-5. **Direct entitlements emission**: Convert each entitlement into a platform
-   attribute reference (e.g., `arkavo.ai/classification/restricted`).
-6. **Device ceiling**: If the subject is an NPE (non-person entity), apply the
-   ceiling for its device class.
+2. **Issuer check (token path only)**: If `trust_materialized_claims` is on,
+   verify that the token's `iss` claim matches `trusted_issuer` (or skip if
+   `trusted_issuer` is empty).
+3. **Marker and claims storage**: If the issuer check passes, set
+   `arkavo_trusted: true` and store `arkavo_entitlements` and `arkavo_npe` in
+   the SUBJECT entity's claims.
+4. **Entity synthesis**: Create a SUBJECT entity carrying the claims, and an
+   ENVIRONMENT entity if the token includes an `arkavo_npe` block.
+5. **Claims-entity resolution**: On the second pass, `ResolveEntities` checks
+   `trust_materialized_claims && claims["arkavo_trusted"] == true` to decide
+   whether to emit direct entitlements.
+6. **Direct entitlements emission**: Convert `arkavo_entitlements` into platform
+   attribute FQNs (e.g., `https://arkavo.ai/attr/classification/value/restricted`).
+7. **Device ceiling**: If the subject is a device NPE (non-person entity), apply
+   the ceiling for its device class.
 
 Subject mappings are not used — all authorization flows through direct
 entitlements and the policy snapshot vocabulary.

--- a/service/entityresolution/arkavo/v2/README.md
+++ b/service/entityresolution/arkavo/v2/README.md
@@ -2,16 +2,18 @@
 
 An Arkavo-backed Entity Resolution Service (ERS) for distributed identity and
 authorization within the Arkavo ecosystem. It accepts both JOSE (JWT) and COSE
-(CWT) tokens carrying materialized `arkavo_entitlements` claims, verified by
-a trusted authnz-rs issuer, and translates those claims directly into platform
-entitlements. Pairs with
+(CWT) tokens, already signature-verified upstream by the platform's authn
+middleware, and — when the token's issuer is trusted (see Trust Model below)
+— translates their materialized `arkavo_entitlements` claim directly into
+platform entitlements. Pairs with
 [`examples/config/policy.arkavo.yaml`](../../../../examples/config/policy.arkavo.yaml).
 
 ## What it does
 
 When a subject's claims carry the `arkavo_entitlements` claim (in JWT or CWT
-form), the provider emits **direct entitlements** per claim assertion — in the
-entitlements namespace with dynamic attribute values:
+form) and the issuer is trusted, the provider emits **direct entitlements**
+per claim assertion, verbatim as platform attribute value FQNs declared in
+the operator's policy snapshot, e.g.:
 
 ```
 https://arkavo.ai/attr/classification/value/<classification>
@@ -19,14 +21,16 @@ https://arkavo.ai/attr/action/value/<action>
 https://arkavo.ai/attr/mesh/value/<mesh_role>
 ```
 
-Attribute *values* are dynamic (resolved as synthetic values when
-`allow_direct_entitlements` is on), so onboarding agents requires zero policy
-changes. The provider also surfaces a flattened `.arkavo.*` view for legacy
-subject mappings derived from the same claim.
+Attribute *values* under an already-declared attribute (namespace + name) are
+dynamic (resolved as synthetic values when `allow_direct_entitlements` is
+on), so onboarding a new entitlement value requires no change to the policy
+snapshot — only a new namespace or attribute name does.
 
-It also supports Non-Person Entities (NPE) — service accounts and agents — by
-resolving their client IDs and applying device class ceilings (e.g., an
-`unverified` agent can only access `internal` data).
+It also supports Non-Person Entities (NPE) — device and agent tokens — by
+resolving their client IDs. Device class ceilings additionally cap a
+*device* NPE's direct entitlements to its attested class (e.g., an
+`unverified` device can only access `internal` data); agent NPEs are not
+subject to a ceiling.
 
 ## Configuration
 
@@ -56,8 +60,10 @@ services:
       managed:    ["https://arkavo.ai/attr/classification/value/confidential"]
       attested:   ["https://arkavo.ai/attr/classification/value/restricted"]
 
-    # JWT claim overrides (defaults shown). These control which claim names
-    # carry the entitlements, client ID, and user ID.
+    # Claim name override (default shown). Controls which claim carries the
+    # PE account ID surfaced on the SUBJECT entity; the entitlements
+    # (arkavo_entitlements), user ID (sub), and issuer (iss) claim names are
+    # fixed and not configurable.
     client_id_claim: arkavo_account_id
 ```
 
@@ -78,8 +84,9 @@ master switch.
 When `CreateEntityChainsFromTokens` processes a token, it checks the issuer
 against `trusted_issuer` (if `trust_materialized_claims` is on). If the check
 passes, it stamps `arkavo_trusted: true` onto the SUBJECT entity's claims,
-along with `arkavo_entitlements` and the raw `arkavo_npe` data. This marker
-carries the issuer decision forward into the claims-entity path.
+along with `arkavo_roles`, `arkavo_entitlements`, and the raw `arkavo_npe`
+data — all self-asserted, materialized-claims data gated by the same check.
+This marker carries the issuer decision forward into the claims-entity path.
 
 ### Two-Path Resolution
 
@@ -114,15 +121,17 @@ entirely — no marker check avoids this setting.
    verify that the token's `iss` claim matches `trusted_issuer` (or skip if
    `trusted_issuer` is empty).
 3. **Marker and claims storage**: If the issuer check passes, set
-   `arkavo_trusted: true` and store `arkavo_entitlements` and `arkavo_npe` in
-   the SUBJECT entity's claims.
+   `arkavo_trusted: true` and store `arkavo_roles`, `arkavo_entitlements`, and
+   `arkavo_npe` in the SUBJECT entity's claims.
 4. **Entity synthesis**: Create a SUBJECT entity carrying the claims, and an
    ENVIRONMENT entity if the token includes an `arkavo_npe` block.
 5. **Claims-entity resolution**: On the second pass, `ResolveEntities` checks
    `trust_materialized_claims && claims["arkavo_trusted"] == true` to decide
    whether to emit direct entitlements.
-6. **Direct entitlements emission**: Convert `arkavo_entitlements` into platform
-   attribute FQNs (e.g., `https://arkavo.ai/attr/classification/value/restricted`).
+6. **Direct entitlements emission**: Emit each `arkavo_entitlements` value
+   (already a platform attribute value FQN, e.g.
+   `https://arkavo.ai/attr/classification/value/restricted`) as a direct
+   entitlement, lowercased and deduplicated.
 7. **Device ceiling**: If the subject is a device NPE (non-person entity), apply
    the ceiling for its device class.
 

--- a/service/entityresolution/arkavo/v2/README.md
+++ b/service/entityresolution/arkavo/v2/README.md
@@ -12,8 +12,8 @@ platform entitlements. Pairs with
 
 When a subject's claims carry the `arkavo_entitlements` claim (in JWT or CWT
 form) and the issuer is trusted, the provider emits **direct entitlements**
-per claim assertion, verbatim as platform attribute value FQNs declared in
-the operator's policy snapshot, e.g.:
+per claim assertion (lowercased and deduplicated) as platform attribute
+value FQNs declared in the operator's policy snapshot, e.g.:
 
 ```
 https://arkavo.ai/attr/classification/value/<classification>

--- a/service/entityresolution/arkavo/v2/README.md
+++ b/service/entityresolution/arkavo/v2/README.md
@@ -1,0 +1,99 @@
+# Arkavo Entity Resolution Provider (v2)
+
+An Arkavo-backed Entity Resolution Service (ERS) for distributed identity and
+authorization within the Arkavo ecosystem. It accepts both JOSE (JWT) and COSE
+(CWT) tokens carrying materialized `arkavo_entitlements` claims, verified by
+a trusted authnz-rs issuer, and translates those claims directly into platform
+entitlements. Pairs with
+[`examples/config/policy.arkavo.yaml`](../../../../examples/config/policy.arkavo.yaml).
+
+## What it does
+
+When a subject's claims carry the `arkavo_entitlements` claim (in JWT or CWT
+form), the provider emits **direct entitlements** per claim assertion — in the
+entitlements namespace with dynamic attribute values:
+
+```
+https://arkavo.ai/attr/classification/value/<classification>
+https://arkavo.ai/attr/action/value/<action>
+https://arkavo.ai/attr/mesh/value/<mesh_role>
+```
+
+Attribute *values* are dynamic (resolved as synthetic values when
+`allow_direct_entitlements` is on), so onboarding agents requires zero policy
+changes. The provider also surfaces a flattened `.arkavo.*` view for legacy
+subject mappings derived from the same claim.
+
+It also supports Non-Person Entities (NPE) — service accounts and agents — by
+resolving their client IDs and applying device class ceilings (e.g., an
+`unverified` agent can only access `internal` data).
+
+## Configuration
+
+```yaml
+services:
+  entityresolution:
+    mode: arkavo
+
+    # SECURITY: the materialized arkavo_entitlements claim is authoritative.
+    # Off by default; enable only when every decision caller reaches the ERS
+    # through a trusted channel (the platform's verified-token path, or a
+    # role:standard PEP that verified the subject token). Pin the materializer
+    # with trusted_issuer.
+    trust_materialized_claims: true
+    trusted_issuer: http://127.0.0.1:8081
+
+    # Platform actions (read, create, update, delete) that direct entitlements
+    # may grant. `decrypt` is NOT an action — it appears only as an attribute
+    # value under the `tdf` attribute.
+    direct_entitlement_actions: [read]
+
+    # Device class ceilings: non-person entities (NPE) with a device_class
+    # attribute value are capped to the corresponding classification level.
+    # A device can only access data at its ceiling or lower.
+    device_class_ceilings:
+      unverified: ["https://arkavo.ai/attr/classification/value/internal"]
+      managed:    ["https://arkavo.ai/attr/classification/value/confidential"]
+      attested:   ["https://arkavo.ai/attr/classification/value/restricted"]
+
+    # JWT claim overrides (defaults shown). These control which claim names
+    # carry the entitlements, client ID, and user ID.
+    client_id_claim: arkavo_account_id
+```
+
+The authorization service must also set `allow_direct_entitlements: true`
+(and typically `enforce_namespaced_entitlements: true`) for the dynamic
+values to be honored.
+
+## Trust Model
+
+Arkavo entitlements are signed upstream at authnz-rs and verified by the
+platform's token validation layer before reaching the ERS. The ERS trusts
+only tokens from the `trusted_issuer` pin — all other issuers are rejected.
+
+### Entity Resolution Flow
+
+1. **Token arrives at ERS**: JWT (JOSE) or CWT (COSE), signature already verified
+   by the platform's authn middleware.
+2. **Issuer check**: If `trust_materialized_claims` is on, verify that the token
+   comes from the `trusted_issuer`.
+3. **Claims extraction**: Extract `arkavo_entitlements`, `arkavo_account_id`
+   (client ID), and other claims.
+4. **Entity synthesis**: Create a SUBJECT entity carrying the entitlements claim
+   and a marker indicating it was trust-gated (PEP boundary).
+5. **Direct entitlements emission**: Convert each entitlement into a platform
+   attribute reference (e.g., `arkavo.ai/classification/restricted`).
+6. **Device ceiling**: If the subject is an NPE (non-person entity), apply the
+   ceiling for its device class.
+
+Subject mappings are not used — all authorization flows through direct
+entitlements and the policy snapshot vocabulary.
+
+## Testing
+
+```bash
+cd service && go test ./entityresolution/arkavo/...
+```
+
+No outbound Arkavo or authnz-rs calls — tests exercise claims passthrough
+directly with mocked JWT/CWT payloads.

--- a/service/entityresolution/arkavo/v2/claims.go
+++ b/service/entityresolution/arkavo/v2/claims.go
@@ -12,9 +12,9 @@ import (
 // claimsFromToken accepts either a JOSE JWT (the RAR endpoint's unsigned
 // bridge, or a real JWT) or a base64url CWT (the with_request_token path
 // hands the ERS the raw bearer). Signature verification happened upstream.
-func claimsFromToken(tokenRaw string) (map[string]any, error) {
+func claimsFromToken(ctx context.Context, tokenRaw string) (map[string]any, error) {
 	if parsed, err := jwt.ParseString(tokenRaw, jwt.WithVerify(false), jwt.WithValidate(false)); err == nil {
-		m, err := parsed.AsMap(context.Background())
+		m, err := parsed.AsMap(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("read jwt claims: %w", err)
 		}

--- a/service/entityresolution/arkavo/v2/claims.go
+++ b/service/entityresolution/arkavo/v2/claims.go
@@ -1,0 +1,106 @@
+package arkavo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/opentdf/platform/service/internal/auth"
+)
+
+// claimsFromToken accepts either a JOSE JWT (the RAR endpoint's unsigned
+// bridge, or a real JWT) or a base64url CWT (the with_request_token path
+// hands the ERS the raw bearer). Signature verification happened upstream.
+func claimsFromToken(tokenRaw string) (map[string]any, error) {
+	if parsed, err := jwt.ParseString(tokenRaw, jwt.WithVerify(false), jwt.WithValidate(false)); err == nil {
+		m, err := parsed.AsMap(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("read jwt claims: %w", err)
+		}
+		return m, nil
+	}
+	m, err := auth.DecodeCWTClaimsFromToken(tokenRaw)
+	if err != nil {
+		return nil, fmt.Errorf("token is neither JWT nor CWT: %w", err)
+	}
+	return m, nil
+}
+
+type npeClaim struct {
+	Type              string
+	Class             string
+	DeviceID          string
+	DelegationID      string
+	AttestationExpiry int64
+	Depth             int64
+	Chain             []string
+}
+
+type arkavoClaims struct {
+	Iss, Sub, AccountID string
+	Roles, Entitlements []string
+	Npe                 *npeClaim
+	Actors              []string
+	Raw                 map[string]any
+}
+
+func strList(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, isStr := it.(string); isStr && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func asInt64(v any) int64 {
+	switch x := v.(type) {
+	case int64:
+		return x
+	case int:
+		return int64(x)
+	case uint64:
+		return int64(x)
+	case float64:
+		return int64(x)
+	}
+	return 0
+}
+
+func parseArkavoClaims(m map[string]any) arkavoClaims {
+	c := arkavoClaims{Raw: m}
+	c.Iss, _ = m["iss"].(string)
+	c.Sub, _ = m["sub"].(string)
+	c.AccountID, _ = m["arkavo_account_id"].(string)
+	c.Roles = strList(m["arkavo_roles"])
+	c.Entitlements = strList(m["arkavo_entitlements"])
+	if raw, ok := m["arkavo_npe"].(map[string]any); ok {
+		n := &npeClaim{}
+		n.Type, _ = raw["type"].(string)
+		n.Class, _ = raw["class"].(string)
+		n.DeviceID, _ = raw["device_id"].(string)
+		n.DelegationID, _ = raw["delegation_id"].(string)
+		n.AttestationExpiry = asInt64(raw["attestation_expiry"])
+		n.Depth = asInt64(raw["depth"])
+		n.Chain = strList(raw["chain"])
+		if n.Type != "" {
+			c.Npe = n
+		}
+	}
+	if acts, isSlice := m["act"].([]any); isSlice {
+		for _, a := range acts {
+			if am, isMap := a.(map[string]any); isMap {
+				if s, isStr := am["sub"].(string); isStr && s != "" {
+					c.Actors = append(c.Actors, s)
+				}
+			}
+		}
+	}
+	return c
+}

--- a/service/entityresolution/arkavo/v2/claims_test.go
+++ b/service/entityresolution/arkavo/v2/claims_test.go
@@ -1,0 +1,96 @@
+package arkavo
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// buildJWT encodes claims as a compact, unsigned (alg=none) JWT, mirroring
+// encodeUnsignedJWT in service/internal/auth/cwt_verifier.go — the exact
+// wire format the fork's verified-CWT-to-unsigned-JWT bridge hands the ERS.
+func buildJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(body) + "."
+}
+
+func TestClaimsFromToken_JOSEThenCWT(t *testing.T) {
+	jose := buildJWT(t, map[string]interface{}{"iss": "i", "sub": "s"})
+	m, err := claimsFromToken(jose)
+	if err != nil || m["sub"] != "s" {
+		t.Fatalf("jose: %v %v", m, err)
+	}
+	if _, err := claimsFromToken("definitely-not-a-token"); err == nil {
+		t.Error("garbage must fail")
+	}
+}
+
+func TestParseArkavoClaims_AgentShape(t *testing.T) {
+	m := map[string]any{
+		"iss":                 "https://identity.arkavo.net",
+		"sub":                 "did:key:z6Mkabc",
+		"arkavo_account_id":   "00000000-0000-0000-0000-000000000001",
+		"arkavo_roles":        []any{"agent"},
+		"arkavo_entitlements": []any{"https://arkavo.ai/attr/tdf/value/decrypt"},
+		"arkavo_npe": map[string]any{
+			"type": "agent", "delegation_id": "did:key:z6Mkabc", "depth": int64(0), "chain": []any{},
+		},
+		"act": []any{map[string]any{"sub": "https://kg.arkavo.net"}},
+	}
+	c := parseArkavoClaims(m)
+	if c.Sub != "did:key:z6Mkabc" || c.AccountID != "00000000-0000-0000-0000-000000000001" {
+		t.Errorf("identity: %+v", c)
+	}
+	if len(c.Entitlements) != 1 || c.Roles[0] != "agent" {
+		t.Errorf("lists: %+v", c)
+	}
+	if c.Npe == nil || c.Npe.Type != "agent" || c.Npe.Depth != 0 {
+		t.Errorf("npe: %+v", c.Npe)
+	}
+	if len(c.Actors) != 1 || c.Actors[0] != "https://kg.arkavo.net" {
+		t.Errorf("act: %v", c.Actors)
+	}
+}
+
+func TestConfigApplyDefaults(t *testing.T) {
+	var c Config
+	c.applyDefaults()
+	if len(c.DirectEntitlementActions) != 1 || c.DirectEntitlementActions[0] != "read" {
+		t.Errorf("direct entitlement actions default: %v", c.DirectEntitlementActions)
+	}
+	if c.ClientIDClaim != "arkavo_account_id" {
+		t.Errorf("client id claim default: %q", c.ClientIDClaim)
+	}
+	if c.DeviceClassCeilings == nil {
+		t.Error("device class ceilings should default to an empty map, not nil")
+	}
+
+	populated := Config{
+		DirectEntitlementActions: []string{"create", "update"},
+		ClientIDClaim:            "custom_claim",
+	}
+	populated.applyDefaults()
+	if len(populated.DirectEntitlementActions) != 2 || populated.DirectEntitlementActions[0] != "create" {
+		t.Errorf("configured actions must not be clobbered: %v", populated.DirectEntitlementActions)
+	}
+	if populated.ClientIDClaim != "custom_claim" {
+		t.Errorf("configured client id claim must not be clobbered: %q", populated.ClientIDClaim)
+	}
+}
+
+func TestParseArkavoClaims_DeviceShape(t *testing.T) {
+	m := map[string]any{
+		"sub": "u", "arkavo_npe": map[string]any{
+			"type": "device", "class": "attested", "attestation_expiry": int64(1800000000), "device_id": "K1",
+		},
+	}
+	c := parseArkavoClaims(m)
+	if c.Npe == nil || c.Npe.Class != "attested" || c.Npe.AttestationExpiry != 1800000000 || c.Npe.DeviceID != "K1" {
+		t.Errorf("device npe: %+v", c.Npe)
+	}
+}

--- a/service/entityresolution/arkavo/v2/claims_test.go
+++ b/service/entityresolution/arkavo/v2/claims_test.go
@@ -21,11 +21,11 @@ func buildJWT(t *testing.T, claims map[string]interface{}) string {
 
 func TestClaimsFromToken_JOSEThenCWT(t *testing.T) {
 	jose := buildJWT(t, map[string]interface{}{"iss": "i", "sub": "s"})
-	m, err := claimsFromToken(jose)
+	m, err := claimsFromToken(t.Context(), jose)
 	if err != nil || m["sub"] != "s" {
 		t.Fatalf("jose: %v %v", m, err)
 	}
-	if _, err := claimsFromToken("definitely-not-a-token"); err == nil {
+	if _, err := claimsFromToken(t.Context(), "definitely-not-a-token"); err == nil {
 		t.Error("garbage must fail")
 	}
 }

--- a/service/entityresolution/arkavo/v2/config.go
+++ b/service/entityresolution/arkavo/v2/config.go
@@ -4,11 +4,9 @@ import "log/slog"
 
 // defaultClientIDClaim is the fallback for Config.ClientIDClaim.
 //
-// NOTE for Task 3: the arkavo_npe.class values (unverified/managed/attested)
-// and npe.type values (agent/device) are used by claims.go's parsing and by
-// the entitlement-shaping logic Task 3 adds, not by this file — define those
-// constants alongside the code that switches on them (mirrors patreon/v2's
-// convention of keeping class/type consts with their consumer).
+// The arkavo_npe.class values (unverified/managed/attested) and npe.type
+// values (agent/device) live in entity_resolution.go, next to the
+// entitlement-shaping and entity-typing code that switches on them.
 const defaultClientIDClaim = "arkavo_account_id"
 
 // Config configures the arkavo claims-passthrough entity resolver.

--- a/service/entityresolution/arkavo/v2/config.go
+++ b/service/entityresolution/arkavo/v2/config.go
@@ -1,0 +1,55 @@
+package arkavo
+
+import "log/slog"
+
+// defaultClientIDClaim is the fallback for Config.ClientIDClaim.
+//
+// NOTE for Task 3: the arkavo_npe.class values (unverified/managed/attested)
+// and npe.type values (agent/device) are used by claims.go's parsing and by
+// the entitlement-shaping logic Task 3 adds, not by this file — define those
+// constants alongside the code that switches on them (mirrors patreon/v2's
+// convention of keeping class/type consts with their consumer).
+const defaultClientIDClaim = "arkavo_account_id"
+
+// Config configures the arkavo claims-passthrough entity resolver.
+type Config struct {
+	// TrustMaterializedClaims enables emitting direct entitlements from the
+	// token's arkavo_entitlements. Default false: without it this provider
+	// only shapes entities and grants nothing. See patreon/v2 for the trust
+	// rationale — the token signature is verified upstream by the authn
+	// interceptor; TrustedIssuer pins which IdP's tokens are honored.
+	TrustMaterializedClaims bool `mapstructure:"trust_materialized_claims" json:"trust_materialized_claims"`
+	// TrustedIssuer must equal the token's iss for entitlements to be honored.
+	TrustedIssuer string `mapstructure:"trusted_issuer" json:"trusted_issuer"`
+	// DirectEntitlementActions are the action names attached to every
+	// emitted entitlement. Standard lowercase names only. Default ["read"].
+	DirectEntitlementActions []string `mapstructure:"direct_entitlement_actions" json:"direct_entitlement_actions"`
+	// DeviceClassCeilings maps arkavo_npe.class -> attribute value FQNs a
+	// device token is entitled to when presented as its own subject.
+	DeviceClassCeilings map[string][]string `mapstructure:"device_class_ceilings" json:"device_class_ceilings"`
+	// ClientIDClaim names the claim carrying the PE account id.
+	ClientIDClaim string `mapstructure:"client_id_claim" json:"client_id_claim"`
+}
+
+// LogValue keeps config logging structured; nothing here is secret.
+func (c Config) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("trust_materialized_claims", c.TrustMaterializedClaims),
+		slog.String("trusted_issuer", c.TrustedIssuer),
+		slog.Any("direct_entitlement_actions", c.DirectEntitlementActions),
+		slog.Int("device_class_ceilings", len(c.DeviceClassCeilings)),
+		slog.String("client_id_claim", c.ClientIDClaim),
+	)
+}
+
+func (c *Config) applyDefaults() {
+	if len(c.DirectEntitlementActions) == 0 {
+		c.DirectEntitlementActions = []string{"read"}
+	}
+	if c.ClientIDClaim == "" {
+		c.ClientIDClaim = defaultClientIDClaim
+	}
+	if c.DeviceClassCeilings == nil {
+		c.DeviceClassCeilings = map[string][]string{}
+	}
+}

--- a/service/entityresolution/arkavo/v2/config.go
+++ b/service/entityresolution/arkavo/v2/config.go
@@ -4,9 +4,9 @@ import "log/slog"
 
 // defaultClientIDClaim is the fallback for Config.ClientIDClaim.
 //
-// The arkavo_npe.class values (unverified/managed/attested) and npe.type
-// values (agent/device) live in entity_resolution.go, next to the
-// entitlement-shaping and entity-typing code that switches on them.
+// DeviceClassCeilings keys are arkavo_npe.class values (e.g.
+// unverified/managed/attested); the code that applies them switches only on
+// the "unverified" default, in entity_resolution.go.
 const defaultClientIDClaim = "arkavo_account_id"
 
 // Config configures the arkavo claims-passthrough entity resolver.

--- a/service/entityresolution/arkavo/v2/entity_resolution.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution.go
@@ -6,8 +6,10 @@ package arkavo
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/go-viper/mapstructure/v2"
@@ -35,9 +37,12 @@ const (
 
 // trustedMarker is set on the subject entity's claims by entitiesFromToken
 // after the issuer check, so ResolveEntities (second pass, no token) can
-// honor entitlements without re-checking iss. A caller-supplied claims
-// entity can forge it — that path is guarded by the PEP's role:standard
-// credential, exactly as in the patreon provider.
+// honor entitlements without re-checking iss. A caller-supplied claims entity
+// can forge this marker, so ResolveEntities never treats it as sufficient on
+// its own: it also re-asserts the operator's TrustMaterializedClaims master
+// switch before honoring it (the TrustedIssuer comparison itself cannot be
+// redone in this second pass — the marker is what carries that decision
+// forward, but the master switch can and must be re-checked).
 const trustedMarker = "arkavo_trusted"
 
 type EntityResolutionService struct {
@@ -107,7 +112,12 @@ func (s *EntityResolutionService) ResolveEntities(
 			}
 			claims := st.AsMap()
 			rep.AdditionalProps = []*structpb.Struct{&st}
-			if claims[trustedMarker] == true {
+			// trustedMarker alone is not sufficient: a caller-supplied Entity_Claims
+			// payload can fabricate it, so the operator's master switch
+			// (TrustMaterializedClaims) must be re-asserted here even though the
+			// TrustedIssuer comparison cannot be redone in this second pass (the
+			// marker is what carries that earlier decision forward).
+			if s.cfg.TrustMaterializedClaims && claims[trustedMarker] == true {
 				rep.DirectEntitlements = s.directEntitlements(parseArkavoClaims(claims))
 			}
 		}
@@ -153,7 +163,9 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, tokenRa
 			subjectClaims["arkavo_entitlements"] = toAnySlice(c.Entitlements)
 		}
 		if raw, ok := m["arkavo_npe"].(map[string]any); ok {
-			subjectClaims["arkavo_npe"] = raw
+			if safe, safeOK := structpbSafe(raw); safeOK {
+				subjectClaims["arkavo_npe"] = safe
+			}
 		}
 	}
 	st, err := structpb.NewStruct(subjectClaims)
@@ -187,6 +199,50 @@ func toAnySlice(in []string) []any {
 		out[i] = s
 	}
 	return out
+}
+
+// structpbSafe recursively converts v into a shape structpb.NewStruct can
+// accept, dropping any element it cannot represent. It exists because
+// normalizeCBOR's CWT decode path (service/internal/auth/cwt_verifier.go)
+// hands back native Go types for values structpb.NewStruct rejects outright —
+// time.Time for CBOR tag-0/tag-1 timestamps, []byte for byte strings, and
+// uint64 — so a legitimately signed, trusted-issuer CWT carrying e.g. an
+// attestation_expiry timestamp must not fail the whole
+// CreateEntityChainsFromTokens call with a 500. It is applied only to the raw
+// arkavo_npe map, never rebuilt from the typed npeClaim struct, so any field
+// the spec has not yet named is still carried through for audit.
+func structpbSafe(v any) (any, bool) {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			if sv, ok := structpbSafe(vv); ok {
+				out[k] = sv
+			}
+		}
+		return out, true
+	case []any:
+		out := make([]any, 0, len(x))
+		for _, vv := range x {
+			if sv, ok := structpbSafe(vv); ok {
+				out = append(out, sv)
+			}
+		}
+		return out, true
+	case time.Time:
+		return x.Unix(), true
+	case []byte:
+		return base64.RawURLEncoding.EncodeToString(x), true
+	case uint64:
+		return int64(x), true
+	case nil, bool, string,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32,
+		float32, float64:
+		return v, true
+	default:
+		return nil, false
+	}
 }
 
 func (s *EntityResolutionService) directEntitlements(c arkavoClaims) []*entityresolutionV2.DirectEntitlement {

--- a/service/entityresolution/arkavo/v2/entity_resolution.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution.go
@@ -1,0 +1,214 @@
+// Package arkavo is the claims-passthrough Entity Resolution Service for
+// authnz-rs (identity.arkavo.net) tokens. It emits the person (PE) as the
+// SUBJECT entity, each arkavo_npe (agent, device) as an ENVIRONMENT entity,
+// and direct entitlements from arkavo_entitlements — no subject mappings.
+package arkavo
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/opentdf/platform/protocol/go/entity"
+	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	ent "github.com/opentdf/platform/service/entity"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/pkg/config"
+	"github.com/opentdf/platform/service/pkg/serviceregistry"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// arkavo_npe.class values (see authnz-rs's device attestation ladder) and
+// arkavo_npe.type values. Re-added here per Task 3 (see config.go's NOTE) —
+// this is the code that switches on them.
+const (
+	classUnverified = "unverified"
+	classManaged    = "managed"
+	classAttested   = "attested"
+	npeTypeAgent    = "agent"
+	npeTypeDevice   = "device"
+)
+
+// trustedMarker is set on the subject entity's claims by entitiesFromToken
+// after the issuer check, so ResolveEntities (second pass, no token) can
+// honor entitlements without re-checking iss. A caller-supplied claims
+// entity can forge it — that path is guarded by the PEP's role:standard
+// credential, exactly as in the patreon provider.
+const trustedMarker = "arkavo_trusted"
+
+type EntityResolutionService struct {
+	entityresolutionV2.UnimplementedEntityResolutionServiceServer
+	cfg    Config
+	logger *logger.Logger
+	trace.Tracer
+}
+
+func RegisterArkavoERS(cfg config.ServiceConfig, log *logger.Logger) (*EntityResolutionService, serviceregistry.HandlerServer) {
+	var c Config
+	if err := mapstructure.Decode(cfg, &c); err != nil {
+		log.Error("failed to decode arkavo entity resolution config", slog.Any("error", err))
+		panic(fmt.Sprintf("failed to decode arkavo entity resolution config: %v", err))
+	}
+	c.applyDefaults()
+	log.Debug("arkavo entity resolution configuration", slog.Any("config", c))
+	if c.TrustMaterializedClaims && c.TrustedIssuer == "" {
+		log.Warn("arkavo: trust_materialized_claims is enabled with no trusted_issuer — any token the platform accepts can assert entitlements")
+	}
+	return &EntityResolutionService{cfg: c, logger: log}, nil
+}
+
+func NewERS(cfg Config, log *logger.Logger) *EntityResolutionService {
+	cfg.applyDefaults()
+	return &EntityResolutionService{cfg: cfg, logger: log}
+}
+
+// CreateEntityChainsFromTokens: one chain per token. Accepts JOSE or CWT.
+func (s *EntityResolutionService) CreateEntityChainsFromTokens(
+	ctx context.Context,
+	req *connect.Request[entityresolutionV2.CreateEntityChainsFromTokensRequest],
+) (*connect.Response[entityresolutionV2.CreateEntityChainsFromTokensResponse], error) {
+	ctx, span := s.Start(ctx, "CreateEntityChainsFromTokens")
+	defer span.End()
+	chains := make([]*entity.EntityChain, 0, len(req.Msg.GetTokens()))
+	for _, tok := range req.Msg.GetTokens() {
+		entities, err := s.entitiesFromToken(ctx, tok.GetJwt())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		chains = append(chains, &entity.EntityChain{EphemeralId: tok.GetEphemeralId(), Entities: entities})
+	}
+	return connect.NewResponse(&entityresolutionV2.CreateEntityChainsFromTokensResponse{EntityChains: chains}), nil
+}
+
+// ResolveEntities: a claims entity carrying the trusted marker yields direct
+// entitlements: arkavo_entitlements verbatim, plus the class ceiling when the
+// claims describe a device NPE. Everything else resolves with no entitlements.
+func (s *EntityResolutionService) ResolveEntities(
+	ctx context.Context,
+	req *connect.Request[entityresolutionV2.ResolveEntitiesRequest],
+) (*connect.Response[entityresolutionV2.ResolveEntitiesResponse], error) {
+	_, span := s.Start(ctx, "ResolveEntities")
+	defer span.End()
+	reps := make([]*entityresolutionV2.EntityRepresentation, 0, len(req.Msg.GetEntities()))
+	for i, e := range req.Msg.GetEntities() {
+		id := e.GetEphemeralId()
+		if id == "" {
+			id = fmt.Sprintf("%s%d", ent.EntityIDPrefix, i)
+		}
+		rep := &entityresolutionV2.EntityRepresentation{OriginalId: id}
+		if claimsEntity, ok := e.GetEntityType().(*entity.Entity_Claims); ok {
+			var st structpb.Struct
+			if err := claimsEntity.Claims.UnmarshalTo(&st); err != nil {
+				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unpack claims: %w", err))
+			}
+			claims := st.AsMap()
+			rep.AdditionalProps = []*structpb.Struct{&st}
+			if claims[trustedMarker] == true {
+				rep.DirectEntitlements = s.directEntitlements(parseArkavoClaims(claims))
+			}
+		}
+		reps = append(reps, rep)
+	}
+	return connect.NewResponse(&entityresolutionV2.ResolveEntitiesResponse{EntityRepresentations: reps}), nil
+}
+
+func (s *EntityResolutionService) issuerTrusted(c arkavoClaims) bool {
+	return s.cfg.TrustMaterializedClaims && (s.cfg.TrustedIssuer == "" || c.Iss == s.cfg.TrustedIssuer)
+}
+
+func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, tokenRaw string) ([]*entity.Entity, error) {
+	m, err := claimsFromToken(ctx, tokenRaw)
+	if err != nil {
+		return nil, err
+	}
+	c := parseArkavoClaims(m)
+	trusted := s.issuerTrusted(c)
+
+	out := []*entity.Entity{}
+	// NPE (agent or device) as an ENVIRONMENT entity — audited, never evaluated.
+	if c.Npe != nil {
+		out = append(out, &entity.Entity{
+			EntityType:  &entity.Entity_ClientId{ClientId: npeID(c)},
+			EphemeralId: "arkavo-npe-" + c.Npe.Type,
+			Category:    entity.Entity_CATEGORY_ENVIRONMENT,
+		})
+	}
+
+	// SUBJECT: the PE for person/device tokens; the agent DID for agent tokens
+	// (agent tokens are evaluated as their own subject — spec §1, choice A).
+	subjectClaims := map[string]any{"sub": c.Sub, "iss": c.Iss}
+	if c.AccountID != "" {
+		subjectClaims[s.cfg.ClientIDClaim] = c.AccountID
+	}
+	if len(c.Roles) > 0 {
+		subjectClaims["arkavo_roles"] = toAnySlice(c.Roles)
+	}
+	if trusted {
+		subjectClaims[trustedMarker] = true
+		if len(c.Entitlements) > 0 {
+			subjectClaims["arkavo_entitlements"] = toAnySlice(c.Entitlements)
+		}
+		if raw, ok := m["arkavo_npe"].(map[string]any); ok {
+			subjectClaims["arkavo_npe"] = raw
+		}
+	}
+	st, err := structpb.NewStruct(subjectClaims)
+	if err != nil {
+		return nil, err
+	}
+	anyClaims, err := anypb.New(st)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, &entity.Entity{
+		EntityType:  &entity.Entity_Claims{Claims: anyClaims},
+		EphemeralId: "arkavo-subject",
+		Category:    entity.Entity_CATEGORY_SUBJECT,
+	})
+	return out, nil
+}
+
+func npeID(c arkavoClaims) string {
+	switch c.Npe.Type {
+	case npeTypeDevice:
+		return "device:" + c.Npe.DeviceID
+	default:
+		return c.Sub
+	}
+}
+
+func toAnySlice(in []string) []any {
+	out := make([]any, len(in))
+	for i, s := range in {
+		out[i] = s
+	}
+	return out
+}
+
+func (s *EntityResolutionService) directEntitlements(c arkavoClaims) []*entityresolutionV2.DirectEntitlement {
+	fqns := append([]string{}, c.Entitlements...)
+	if c.Npe != nil && c.Npe.Type == npeTypeDevice {
+		class := c.Npe.Class
+		if class == "" {
+			class = classUnverified
+		}
+		fqns = append(fqns, s.cfg.DeviceClassCeilings[class]...)
+	}
+	out := make([]*entityresolutionV2.DirectEntitlement, 0, len(fqns))
+	seen := map[string]bool{}
+	for _, fqn := range fqns {
+		if fqn == "" || seen[fqn] {
+			continue
+		}
+		seen[fqn] = true
+		out = append(out, &entityresolutionV2.DirectEntitlement{
+			AttributeValueFqn: fqn,
+			Actions:           append([]string{}, s.cfg.DirectEntitlementActions...),
+		})
+	}
+	return out
+}

--- a/service/entityresolution/arkavo/v2/entity_resolution.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -24,14 +25,11 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// arkavo_npe.class values (see authnz-rs's device attestation ladder) and
-// arkavo_npe.type values. Re-added here per Task 3 (see config.go's NOTE) —
-// this is the code that switches on them.
+// classUnverified is the default arkavo_npe.class when a device token omits
+// it. npeTypeDevice is the arkavo_npe.type value that makes a device NPE
+// subject to DeviceClassCeilings.
 const (
 	classUnverified = "unverified"
-	classManaged    = "managed"
-	classAttested   = "attested"
-	npeTypeAgent    = "agent"
 	npeTypeDevice   = "device"
 )
 
@@ -96,7 +94,7 @@ func (s *EntityResolutionService) ResolveEntities(
 	ctx context.Context,
 	req *connect.Request[entityresolutionV2.ResolveEntitiesRequest],
 ) (*connect.Response[entityresolutionV2.ResolveEntitiesResponse], error) {
-	_, span := s.Start(ctx, "ResolveEntities")
+	ctx, span := s.Start(ctx, "ResolveEntities")
 	defer span.End()
 	reps := make([]*entityresolutionV2.EntityRepresentation, 0, len(req.Msg.GetEntities()))
 	for i, e := range req.Msg.GetEntities() {
@@ -108,6 +106,10 @@ func (s *EntityResolutionService) ResolveEntities(
 		if claimsEntity, ok := e.GetEntityType().(*entity.Entity_Claims); ok {
 			var st structpb.Struct
 			if err := claimsEntity.Claims.UnmarshalTo(&st); err != nil {
+				s.logger.ErrorContext(ctx, "failed to unpack claims entity",
+					slog.Any("error", err),
+					slog.String("entity_id", id),
+				)
 				return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unpack claims: %w", err))
 			}
 			claims := st.AsMap()
@@ -149,24 +151,15 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, tokenRa
 	}
 
 	// SUBJECT: the PE for person/device tokens; the agent DID for agent tokens
-	// (agent tokens are evaluated as their own subject — spec §1, choice A).
+	// (an agent token is evaluated as its own subject, not via a delegating
+	// human's identity).
 	subjectClaims := map[string]any{"sub": c.Sub, "iss": c.Iss}
 	if c.AccountID != "" {
 		subjectClaims[s.cfg.ClientIDClaim] = c.AccountID
 	}
-	if len(c.Roles) > 0 {
-		subjectClaims["arkavo_roles"] = toAnySlice(c.Roles)
-	}
 	if trusted {
 		subjectClaims[trustedMarker] = true
-		if len(c.Entitlements) > 0 {
-			subjectClaims["arkavo_entitlements"] = toAnySlice(c.Entitlements)
-		}
-		if raw, ok := m["arkavo_npe"].(map[string]any); ok {
-			if safe, safeOK := structpbSafe(raw); safeOK {
-				subjectClaims["arkavo_npe"] = safe
-			}
-		}
+		addTrustedClaims(subjectClaims, c, m)
 	}
 	st, err := structpb.NewStruct(subjectClaims)
 	if err != nil {
@@ -182,6 +175,25 @@ func (s *EntityResolutionService) entitiesFromToken(ctx context.Context, tokenRa
 		Category:    entity.Entity_CATEGORY_SUBJECT,
 	})
 	return out, nil
+}
+
+// addTrustedClaims adds the self-asserted, materialized-claims data —
+// arkavo_roles, arkavo_entitlements, and the raw arkavo_npe block — that is
+// only surfaced on the subject once the issuer has been trusted.
+func addTrustedClaims(subjectClaims map[string]any, c arkavoClaims, m map[string]any) {
+	if len(c.Roles) > 0 {
+		subjectClaims["arkavo_roles"] = toAnySlice(c.Roles)
+	}
+	if len(c.Entitlements) > 0 {
+		subjectClaims["arkavo_entitlements"] = toAnySlice(c.Entitlements)
+	}
+	raw, ok := m["arkavo_npe"].(map[string]any)
+	if !ok {
+		return
+	}
+	if safe, safeOK := structpbSafe(raw); safeOK {
+		subjectClaims["arkavo_npe"] = safe
+	}
 }
 
 func npeID(c arkavoClaims) string {
@@ -257,6 +269,11 @@ func (s *EntityResolutionService) directEntitlements(c arkavoClaims) []*entityre
 	out := make([]*entityresolutionV2.DirectEntitlement, 0, len(fqns))
 	seen := map[string]bool{}
 	for _, fqn := range fqns {
+		// The PDP lowercases resource-side attribute value FQNs before
+		// matching (service/internal/access/v2), so an entitlement FQN must
+		// be normalized the same way or a mixed-case value silently matches
+		// nothing. Normalizing here also lets seen dedupe case-variants.
+		fqn = strings.ToLower(fqn)
 		if fqn == "" || seen[fqn] {
 			continue
 		}

--- a/service/entityresolution/arkavo/v2/entity_resolution.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution.go
@@ -88,8 +88,9 @@ func (s *EntityResolutionService) CreateEntityChainsFromTokens(
 }
 
 // ResolveEntities: a claims entity carrying the trusted marker yields direct
-// entitlements: arkavo_entitlements verbatim, plus the class ceiling when the
-// claims describe a device NPE. Everything else resolves with no entitlements.
+// entitlements: arkavo_entitlements (lowercased and deduplicated), plus the
+// class ceiling when the claims describe a device NPE. Everything else
+// resolves with no entitlements.
 func (s *EntityResolutionService) ResolveEntities(
 	ctx context.Context,
 	req *connect.Request[entityresolutionV2.ResolveEntitiesRequest],

--- a/service/entityresolution/arkavo/v2/entity_resolution_test.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,6 +119,23 @@ func TestUntrustedIssuer_GrantsNothing(t *testing.T) {
 	}
 }
 
+// TestUntrustedIssuer_RolesNotSurfacedOnSubject: arkavo_roles is
+// self-asserted, materialized-claims data of the same kind as
+// arkavo_entitlements and arkavo_npe, so an untrusted issuer's token must
+// not have it surfaced on the SUBJECT entity either — a subject mapping
+// could otherwise key off it despite the issuer not being trusted.
+func TestUntrustedIssuer_RolesNotSurfacedOnSubject(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	ents := chainsFor(t, svc, agentToken(t, "https://evil.example.com"))
+	claims := subjectClaimsMap(t, ents)
+	if _, present := claims["arkavo_roles"]; present {
+		t.Errorf("untrusted issuer must not surface arkavo_roles on the subject entity, got %v", claims["arkavo_roles"])
+	}
+	if claims["arkavo_trusted"] == true {
+		t.Error("untrusted issuer must not set the arkavo_trusted marker")
+	}
+}
+
 func TestTrustDisabledByDefault(t *testing.T) {
 	svc := newSvc(t, Config{TrustedIssuer: issuer})
 	if got := entitlementsOf(t, svc, chainsFor(t, svc, agentToken(t, issuer))); len(got) != 0 {
@@ -143,6 +161,47 @@ func TestDeviceToken_ClassCeiling(t *testing.T) {
 	}
 }
 
+// TestDirectEntitlements_FQNsLowercasedAndDeduped: the PDP lowercases
+// resource-side attribute value FQNs before matching, so a mixed-case
+// entitlement FQN — whether token-supplied or from an operator-configured
+// device class ceiling — must be lowercased before it is emitted, and case
+// variants of the same FQN must dedupe to a single entitlement.
+func TestDirectEntitlements_FQNsLowercasedAndDeduped(t *testing.T) {
+	svc := newSvc(t, Config{
+		TrustMaterializedClaims: true, TrustedIssuer: issuer,
+		DeviceClassCeilings: map[string][]string{
+			"unverified": {"HTTPS://ARKAVO.AI/ATTR/CLASSIFICATION/VALUE/INTERNAL"},
+		},
+	})
+	tok := buildJWT(t, map[string]interface{}{
+		"iss": issuer, "sub": "00000000-0000-0000-0000-000000000001",
+		"arkavo_entitlements": []interface{}{
+			"HTTPS://ARKAVO.AI/attr/tdf/value/Decrypt",
+			"https://arkavo.ai/attr/tdf/value/decrypt",
+		},
+		"arkavo_npe": map[string]interface{}{"type": "device", "class": "unverified", "device_id": "K1"},
+	})
+	got := entitlementsOf(t, svc, chainsFor(t, svc, tok))
+
+	wantFQNs := []string{
+		"https://arkavo.ai/attr/tdf/value/decrypt",
+		"https://arkavo.ai/attr/classification/value/internal",
+	}
+	if len(got) != len(wantFQNs) {
+		t.Fatalf("got %d entitlements (want %d, mixed-case duplicates must dedupe): %v", len(got), len(wantFQNs), got)
+	}
+	for _, fqn := range wantFQNs {
+		if _, ok := got[fqn]; !ok {
+			t.Errorf("missing lowercased entitlement %s in %v", fqn, got)
+		}
+	}
+	for fqn := range got {
+		if fqn != strings.ToLower(fqn) {
+			t.Errorf("emitted AttributeValueFqn %q is not lowercase", fqn)
+		}
+	}
+}
+
 func TestClaimsEntityPreservesRawForSecondPass(t *testing.T) {
 	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
 	ents := chainsFor(t, svc, agentToken(t, issuer))
@@ -164,7 +223,7 @@ func TestClaimsEntityPreservesRawForSecondPass(t *testing.T) {
 	}
 }
 
-// --- R12: real base64url CWT end-to-end -------------------------------------
+// --- real base64url CWT end-to-end ------------------------------------------
 
 // signCWT mints an in-package COSE_Sign1 CWT (unverified by the ERS, exactly
 // as the with_request_token path hands it the raw bearer). Kept local since
@@ -293,13 +352,13 @@ func TestCWTToken_MatchesEquivalentJWT(t *testing.T) {
 	}
 }
 
-// --- Review findings regression tests ---------------------------------------
+// --- Trust-boundary regression tests -----------------------------------------
 
-// TestResolveEntities_FabricatedTrustedMarkerRejected covers Finding 1: a
-// caller-supplied Entity_Claims payload is not guaranteed to have come from
-// this service's own CreateEntityChainsFromTokens, so a fabricated
-// arkavo_trusted marker must not bypass the operator's master switch
-// (TrustMaterializedClaims: false here).
+// TestResolveEntities_FabricatedTrustedMarkerRejected: a caller-supplied
+// Entity_Claims payload is not guaranteed to have come from this service's
+// own CreateEntityChainsFromTokens, so a fabricated arkavo_trusted marker
+// must not bypass the operator's master switch (TrustMaterializedClaims:
+// false here).
 func TestResolveEntities_FabricatedTrustedMarkerRejected(t *testing.T) {
 	svc := newSvc(t, Config{TrustMaterializedClaims: false, TrustedIssuer: issuer})
 	claims, err := structpb.NewStruct(map[string]interface{}{
@@ -331,10 +390,10 @@ func TestResolveEntities_FabricatedTrustedMarkerRejected(t *testing.T) {
 	}
 }
 
-// TestCWTToken_NpeEpochTimestampAndByteString_Sanitized covers Finding 2: a
-// legitimately signed CWT whose arkavo_npe carries a CBOR tag-1 epoch
-// timestamp and a byte-string field must not fail CreateEntityChainsFromTokens
-// with structpb.NewStruct's "invalid type: time.Time" error — normalizeCBOR
+// TestCWTToken_NpeEpochTimestampAndByteString_Sanitized: a legitimately
+// signed CWT whose arkavo_npe carries a CBOR tag-1 epoch timestamp and a
+// byte-string field must not fail CreateEntityChainsFromTokens with
+// structpb.NewStruct's "invalid type: time.Time" error — normalizeCBOR
 // (service/internal/auth/cwt_verifier.go) hands those back as native
 // time.Time / []byte, and the ERS boundary must sanitize them.
 func TestCWTToken_NpeEpochTimestampAndByteString_Sanitized(t *testing.T) {
@@ -373,9 +432,9 @@ func TestCWTToken_NpeEpochTimestampAndByteString_Sanitized(t *testing.T) {
 	}
 }
 
-// TestCWTToken_NpeNestedStructures_Sanitized covers Finding 2's recursive
-// case: a nested map and a nested list mixing representable values with a
-// CBOR type structpb cannot hold (a big.Int from a tag-2 unsigned bignum).
+// TestCWTToken_NpeNestedStructures_Sanitized covers the recursive case: a
+// nested map and a nested list mixing representable values with a CBOR type
+// structpb cannot hold (a big.Int from a tag-2 unsigned bignum).
 // The call must still succeed, keep representable values, and drop the rest.
 func TestCWTToken_NpeNestedStructures_Sanitized(t *testing.T) {
 	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})

--- a/service/entityresolution/arkavo/v2/entity_resolution_test.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution_test.go
@@ -1,0 +1,292 @@
+package arkavo
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"reflect"
+	"sort"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/opentdf/platform/protocol/go/entity"
+	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/veraison/go-cose"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func testLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	l, err := logger.NewLogger(logger.Config{Level: "error", Output: "stderr", Type: "text"})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	return l
+}
+
+func newSvc(t *testing.T, cfg Config) *EntityResolutionService {
+	t.Helper()
+	svc := NewERS(cfg, testLogger(t))
+	svc.Tracer = noop.NewTracerProvider().Tracer("test")
+	return svc
+}
+
+const issuer = "https://identity.arkavo.net"
+
+func agentToken(t *testing.T, iss string) string {
+	return buildJWT(t, map[string]interface{}{
+		"iss": iss, "sub": "did:key:z6Mkagent",
+		"arkavo_account_id":   "00000000-0000-0000-0000-000000000001",
+		"arkavo_roles":        []interface{}{"agent"},
+		"arkavo_entitlements": []interface{}{"https://arkavo.ai/attr/tdf/value/decrypt", "https://arkavo.ai/attr/action/value/read"},
+		"arkavo_npe":          map[string]interface{}{"type": "agent", "delegation_id": "did:key:z6Mkagent", "depth": 0},
+	})
+}
+
+func chainsFor(t *testing.T, svc *EntityResolutionService, tok string) []*entity.Entity {
+	t.Helper()
+	resp, err := svc.CreateEntityChainsFromTokens(context.Background(), connect.NewRequest(&entityresolutionV2.CreateEntityChainsFromTokensRequest{
+		Tokens: []*entity.Token{{EphemeralId: "t1", Jwt: tok}},
+	}))
+	if err != nil {
+		t.Fatalf("chains: %v", err)
+	}
+	return resp.Msg.GetEntityChains()[0].GetEntities()
+}
+
+func entitlementsOf(t *testing.T, svc *EntityResolutionService, ents []*entity.Entity) map[string][]string {
+	t.Helper()
+	resp, err := svc.ResolveEntities(context.Background(), connect.NewRequest(&entityresolutionV2.ResolveEntitiesRequest{Entities: ents}))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := map[string][]string{}
+	for _, r := range resp.Msg.GetEntityRepresentations() {
+		for _, d := range r.GetDirectEntitlements() {
+			got[d.GetAttributeValueFqn()] = d.GetActions()
+		}
+	}
+	return got
+}
+
+func TestAgentToken_SubjectAndEnvironmentEntities(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	ents := chainsFor(t, svc, agentToken(t, issuer))
+	var subjects, envs int
+	for _, e := range ents {
+		switch e.GetCategory() {
+		case entity.Entity_CATEGORY_SUBJECT:
+			subjects++
+		case entity.Entity_CATEGORY_ENVIRONMENT:
+			envs++
+		case entity.Entity_CATEGORY_UNSPECIFIED:
+			// not expected from this provider
+		}
+	}
+	if subjects != 1 || envs != 1 {
+		t.Fatalf("want 1 subject + 1 environment (agent NPE), got %d/%d", subjects, envs)
+	}
+}
+
+func TestAgentToken_DirectEntitlementsFromClaims(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	got := entitlementsOf(t, svc, chainsFor(t, svc, agentToken(t, issuer)))
+	want := []string{"https://arkavo.ai/attr/tdf/value/decrypt", "https://arkavo.ai/attr/action/value/read"}
+	for _, fqn := range want {
+		acts, ok := got[fqn]
+		if !ok || len(acts) != 1 || acts[0] != "read" {
+			t.Errorf("entitlement %s = %v (want [read])", fqn, acts)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("over-granted: %v", got)
+	}
+}
+
+func TestUntrustedIssuer_GrantsNothing(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	got := entitlementsOf(t, svc, chainsFor(t, svc, agentToken(t, "https://evil.example.com")))
+	if len(got) != 0 {
+		t.Errorf("untrusted issuer leaked entitlements: %v", got)
+	}
+}
+
+func TestTrustDisabledByDefault(t *testing.T) {
+	svc := newSvc(t, Config{TrustedIssuer: issuer})
+	if got := entitlementsOf(t, svc, chainsFor(t, svc, agentToken(t, issuer))); len(got) != 0 {
+		t.Errorf("trust off must grant nothing: %v", got)
+	}
+}
+
+func TestDeviceToken_ClassCeiling(t *testing.T) {
+	svc := newSvc(t, Config{
+		TrustMaterializedClaims: true, TrustedIssuer: issuer,
+		DeviceClassCeilings: map[string][]string{
+			"unverified": {"https://arkavo.ai/attr/classification/value/internal"},
+			"attested":   {"https://arkavo.ai/attr/classification/value/restricted"},
+		},
+	})
+	tok := buildJWT(t, map[string]interface{}{
+		"iss": issuer, "sub": "00000000-0000-0000-0000-000000000001",
+		"arkavo_npe": map[string]interface{}{"type": "device", "class": "unverified", "device_id": "K1"},
+	})
+	got := entitlementsOf(t, svc, chainsFor(t, svc, tok))
+	if _, ok := got["https://arkavo.ai/attr/classification/value/internal"]; !ok || len(got) != 1 {
+		t.Errorf("device ceiling: %v", got)
+	}
+}
+
+func TestClaimsEntityPreservesRawForSecondPass(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	ents := chainsFor(t, svc, agentToken(t, issuer))
+	var subj *entity.Entity
+	for _, e := range ents {
+		if e.GetCategory() == entity.Entity_CATEGORY_SUBJECT {
+			subj = e
+		}
+	}
+	var s structpb.Struct
+	if err := subj.GetClaims().UnmarshalTo(&s); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.AsMap()["arkavo_entitlements"]; !ok {
+		t.Error("arkavo_entitlements must be preserved on the subject entity for the decision flow's second pass")
+	}
+	if s.AsMap()["arkavo_trusted"] != true {
+		t.Error("trusted marker must be set only by entitiesFromToken")
+	}
+}
+
+// --- R12: real base64url CWT end-to-end -------------------------------------
+
+// signCWT mints an in-package COSE_Sign1 CWT (unverified by the ERS, exactly
+// as the with_request_token path hands it the raw bearer). Kept local since
+// package auth's signCWT test helper is not importable.
+func signCWT(t *testing.T, iss, sub string, custom map[any]any) string {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	payload := map[any]any{1: iss, 2: sub}
+	for k, v := range custom {
+		payload[k] = v
+	}
+	payloadCBOR, err := cbor.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	signer, err := cose.NewSigner(cose.AlgorithmES256, priv)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	msg := cose.Sign1Message{
+		Headers: cose.Headers{
+			Protected: cose.ProtectedHeader{cose.HeaderLabelAlgorithm: cose.AlgorithmES256},
+		},
+		Payload: payloadCBOR,
+	}
+	if err := msg.Sign(rand.Reader, nil, signer); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw, err := msg.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("marshal cose: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func agentCWT(t *testing.T, iss string) string {
+	t.Helper()
+	return signCWT(t, iss, "did:key:z6Mkagent", map[any]any{
+		"arkavo_account_id": "00000000-0000-0000-0000-000000000001",
+		"arkavo_roles":      []any{"agent"},
+		"arkavo_entitlements": []any{
+			"https://arkavo.ai/attr/tdf/value/decrypt",
+			"https://arkavo.ai/attr/action/value/read",
+		},
+		"arkavo_npe": map[any]any{"type": "agent", "delegation_id": "did:key:z6Mkagent", "depth": int64(0)},
+	})
+}
+
+func subjectClaimsMap(t *testing.T, ents []*entity.Entity) map[string]interface{} {
+	t.Helper()
+	for _, e := range ents {
+		if e.GetCategory() != entity.Entity_CATEGORY_SUBJECT {
+			continue
+		}
+		var s structpb.Struct
+		if err := e.GetClaims().UnmarshalTo(&s); err != nil {
+			t.Fatalf("unmarshal claims: %v", err)
+		}
+		return s.AsMap()
+	}
+	t.Fatal("no subject entity found")
+	return nil
+}
+
+func TestCWTToken_MatchesEquivalentJWT(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+
+	jwtEnts := chainsFor(t, svc, agentToken(t, issuer))
+	cwtEnts := chainsFor(t, svc, agentCWT(t, issuer))
+
+	var jwtSubjects, jwtEnvs, cwtSubjects, cwtEnvs int
+	for _, e := range jwtEnts {
+		switch e.GetCategory() {
+		case entity.Entity_CATEGORY_SUBJECT:
+			jwtSubjects++
+		case entity.Entity_CATEGORY_ENVIRONMENT:
+			jwtEnvs++
+		case entity.Entity_CATEGORY_UNSPECIFIED:
+			// not expected from this provider
+		}
+	}
+	for _, e := range cwtEnts {
+		switch e.GetCategory() {
+		case entity.Entity_CATEGORY_SUBJECT:
+			cwtSubjects++
+		case entity.Entity_CATEGORY_ENVIRONMENT:
+			cwtEnvs++
+		case entity.Entity_CATEGORY_UNSPECIFIED:
+			// not expected from this provider
+		}
+	}
+	if cwtSubjects != jwtSubjects || cwtEnvs != jwtEnvs {
+		t.Fatalf("CWT chain shape (%d subj/%d env) != JWT chain shape (%d subj/%d env)", cwtSubjects, cwtEnvs, jwtSubjects, jwtEnvs)
+	}
+
+	jwtClaims := subjectClaimsMap(t, jwtEnts)
+	cwtClaims := subjectClaimsMap(t, cwtEnts)
+	if jwtClaims["sub"] != cwtClaims["sub"] || jwtClaims["iss"] != cwtClaims["iss"] {
+		t.Errorf("subject identity mismatch: jwt=%v cwt=%v", jwtClaims, cwtClaims)
+	}
+	if jwtClaims["arkavo_trusted"] != true || cwtClaims["arkavo_trusted"] != true {
+		t.Errorf("both must be trusted: jwt=%v cwt=%v", jwtClaims["arkavo_trusted"], cwtClaims["arkavo_trusted"])
+	}
+
+	jwtGot := entitlementsOf(t, svc, jwtEnts)
+	cwtGot := entitlementsOf(t, svc, cwtEnts)
+	jwtKeys, cwtKeys := make([]string, 0, len(jwtGot)), make([]string, 0, len(cwtGot))
+	for k := range jwtGot {
+		jwtKeys = append(jwtKeys, k)
+	}
+	for k := range cwtGot {
+		cwtKeys = append(cwtKeys, k)
+	}
+	sort.Strings(jwtKeys)
+	sort.Strings(cwtKeys)
+	if !reflect.DeepEqual(jwtKeys, cwtKeys) {
+		t.Fatalf("entitlement FQNs differ: jwt=%v cwt=%v", jwtKeys, cwtKeys)
+	}
+	for _, k := range jwtKeys {
+		if !reflect.DeepEqual(jwtGot[k], cwtGot[k]) {
+			t.Errorf("actions for %s differ: jwt=%v cwt=%v", k, jwtGot[k], cwtGot[k])
+		}
+	}
+}

--- a/service/entityresolution/arkavo/v2/entity_resolution_test.go
+++ b/service/entityresolution/arkavo/v2/entity_resolution_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/fxamacker/cbor/v2"
@@ -17,6 +18,7 @@ import (
 	"github.com/opentdf/platform/service/logger"
 	"github.com/veraison/go-cose"
 	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -288,5 +290,146 @@ func TestCWTToken_MatchesEquivalentJWT(t *testing.T) {
 		if !reflect.DeepEqual(jwtGot[k], cwtGot[k]) {
 			t.Errorf("actions for %s differ: jwt=%v cwt=%v", k, jwtGot[k], cwtGot[k])
 		}
+	}
+}
+
+// --- Review findings regression tests ---------------------------------------
+
+// TestResolveEntities_FabricatedTrustedMarkerRejected covers Finding 1: a
+// caller-supplied Entity_Claims payload is not guaranteed to have come from
+// this service's own CreateEntityChainsFromTokens, so a fabricated
+// arkavo_trusted marker must not bypass the operator's master switch
+// (TrustMaterializedClaims: false here).
+func TestResolveEntities_FabricatedTrustedMarkerRejected(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: false, TrustedIssuer: issuer})
+	claims, err := structpb.NewStruct(map[string]interface{}{
+		"sub":                 "did:key:z6Mkattacker",
+		"iss":                 issuer,
+		"arkavo_trusted":      true,
+		"arkavo_entitlements": []interface{}{"https://arkavo.ai/attr/tdf/value/decrypt", "https://arkavo.ai/attr/action/value/read"},
+	})
+	if err != nil {
+		t.Fatalf("build forged claims: %v", err)
+	}
+	anyClaims, err := anypb.New(claims)
+	if err != nil {
+		t.Fatalf("anypb.New: %v", err)
+	}
+	ents := []*entity.Entity{{
+		EntityType:  &entity.Entity_Claims{Claims: anyClaims},
+		EphemeralId: "forged-subject",
+		Category:    entity.Entity_CATEGORY_SUBJECT,
+	}}
+	resp, err := svc.ResolveEntities(context.Background(), connect.NewRequest(&entityresolutionV2.ResolveEntitiesRequest{Entities: ents}))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	for _, r := range resp.Msg.GetEntityRepresentations() {
+		if got := r.GetDirectEntitlements(); len(got) != 0 {
+			t.Errorf("fabricated arkavo_trusted marker with TrustMaterializedClaims=false must yield zero DirectEntitlements, got %v", got)
+		}
+	}
+}
+
+// TestCWTToken_NpeEpochTimestampAndByteString_Sanitized covers Finding 2: a
+// legitimately signed CWT whose arkavo_npe carries a CBOR tag-1 epoch
+// timestamp and a byte-string field must not fail CreateEntityChainsFromTokens
+// with structpb.NewStruct's "invalid type: time.Time" error — normalizeCBOR
+// (service/internal/auth/cwt_verifier.go) hands those back as native
+// time.Time / []byte, and the ERS boundary must sanitize them.
+func TestCWTToken_NpeEpochTimestampAndByteString_Sanitized(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	expiry := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	nonce := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	tok := signCWT(t, issuer, "did:key:z6Mkdevice", map[any]any{
+		"arkavo_npe": map[any]any{
+			"type":               "device",
+			"device_id":          "K1",
+			"attestation_expiry": cbor.Tag{Number: 1, Content: expiry.Unix()},
+			"attestation_nonce":  nonce,
+		},
+	})
+
+	resp, err := svc.CreateEntityChainsFromTokens(context.Background(), connect.NewRequest(&entityresolutionV2.CreateEntityChainsFromTokensRequest{
+		Tokens: []*entity.Token{{EphemeralId: "t1", Jwt: tok}},
+	}))
+	if err != nil {
+		t.Fatalf("CreateEntityChainsFromTokens must not error on a signed CWT with an epoch-timestamp arkavo_npe field: %v", err)
+	}
+
+	claims := subjectClaimsMap(t, resp.Msg.GetEntityChains()[0].GetEntities())
+	npe, ok := claims["arkavo_npe"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("arkavo_npe missing or wrong shape on subject entity: %#v", claims["arkavo_npe"])
+	}
+	gotExpiry, ok := npe["attestation_expiry"].(float64)
+	if !ok || int64(gotExpiry) != expiry.Unix() {
+		t.Errorf("attestation_expiry = %#v, want %d as a number", npe["attestation_expiry"], expiry.Unix())
+	}
+	wantNonce := base64.RawURLEncoding.EncodeToString(nonce)
+	gotNonce, ok := npe["attestation_nonce"].(string)
+	if !ok || gotNonce != wantNonce {
+		t.Errorf("attestation_nonce = %#v, want %q", npe["attestation_nonce"], wantNonce)
+	}
+}
+
+// TestCWTToken_NpeNestedStructures_Sanitized covers Finding 2's recursive
+// case: a nested map and a nested list mixing representable values with a
+// CBOR type structpb cannot hold (a big.Int from a tag-2 unsigned bignum).
+// The call must still succeed, keep representable values, and drop the rest.
+func TestCWTToken_NpeNestedStructures_Sanitized(t *testing.T) {
+	svc := newSvc(t, Config{TrustMaterializedClaims: true, TrustedIssuer: issuer})
+	tok := signCWT(t, issuer, "did:key:z6Mkdevice", map[any]any{
+		"arkavo_npe": map[any]any{
+			"type":      "device",
+			"device_id": "K1",
+			"nested_map": map[any]any{
+				"keep":    "value",
+				"dropped": cbor.Tag{Number: 2, Content: []byte{0x01, 0x00}}, // unsigned bignum -> big.Int, unrepresentable
+			},
+			"nested_list": []any{
+				"keep-me",
+				int64(7),
+				cbor.Tag{Number: 2, Content: []byte{0x01, 0x00}},
+			},
+		},
+	})
+
+	resp, err := svc.CreateEntityChainsFromTokens(context.Background(), connect.NewRequest(&entityresolutionV2.CreateEntityChainsFromTokensRequest{
+		Tokens: []*entity.Token{{EphemeralId: "t1", Jwt: tok}},
+	}))
+	if err != nil {
+		t.Fatalf("CreateEntityChainsFromTokens must not error on nested unrepresentable arkavo_npe values: %v", err)
+	}
+
+	claims := subjectClaimsMap(t, resp.Msg.GetEntityChains()[0].GetEntities())
+	npe, ok := claims["arkavo_npe"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("arkavo_npe missing or wrong shape on subject entity: %#v", claims["arkavo_npe"])
+	}
+
+	nestedMap, ok := npe["nested_map"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("nested_map missing or wrong shape: %#v", npe["nested_map"])
+	}
+	if got := nestedMap["keep"]; got != "value" {
+		t.Errorf("nested_map[keep] = %#v, want %q", got, "value")
+	}
+	if _, present := nestedMap["dropped"]; present {
+		t.Errorf("nested_map[dropped] should have been dropped as unrepresentable, got %#v", nestedMap["dropped"])
+	}
+
+	nestedList, ok := npe["nested_list"].([]interface{})
+	if !ok {
+		t.Fatalf("nested_list missing or wrong shape: %#v", npe["nested_list"])
+	}
+	if len(nestedList) != 2 {
+		t.Fatalf("nested_list = %#v, want 2 representable elements (unrepresentable one dropped)", nestedList)
+	}
+	if nestedList[0] != "keep-me" {
+		t.Errorf("nested_list[0] = %#v, want %q", nestedList[0], "keep-me")
+	}
+	if n, numOK := nestedList[1].(float64); !numOK || n != 7 {
+		t.Errorf("nested_list[1] = %#v, want 7 as a number", nestedList[1])
 	}
 }

--- a/service/entityresolution/v2/entity_resolution.go
+++ b/service/entityresolution/v2/entity_resolution.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-viper/mapstructure/v2"
 	ersV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
 	"github.com/opentdf/platform/protocol/go/entityresolution/v2/entityresolutionv2connect"
+	arkavov2 "github.com/opentdf/platform/service/entityresolution/arkavo/v2"
 	claims "github.com/opentdf/platform/service/entityresolution/claims/v2"
 	keycloak "github.com/opentdf/platform/service/entityresolution/keycloak/v2"
 	multistrategyv2 "github.com/opentdf/platform/service/entityresolution/multi-strategy/v2"
@@ -27,6 +28,7 @@ const (
 	ClaimsMode        = "claims"
 	MultiStrategyMode = "multi-strategy"
 	PatreonMode       = "patreon"
+	ArkavoMode        = "arkavo"
 )
 
 type EntityResolution struct {
@@ -80,6 +82,10 @@ func NewRegistration() *serviceregistry.Service[entityresolutionv2connect.Entity
 					patreonSVC, patreonHandler := patreonv2.RegisterPatreonERS(srp.Config, srp.Logger)
 					patreonSVC.Tracer = srp.Tracer
 					return EntityResolution{EntityResolutionServiceHandler: patreonSVC, Tracer: srp.Tracer}, patreonHandler
+				case ArkavoMode:
+					arkavoSVC, arkavoHandler := arkavov2.RegisterArkavoERS(srp.Config, srp.Logger)
+					arkavoSVC.Tracer = srp.Tracer
+					return EntityResolution{EntityResolutionServiceHandler: arkavoSVC, Tracer: srp.Tracer}, arkavoHandler
 				default:
 					// Default to Keycloak ERS with cache support
 					kcSVC, kcHandler := keycloak.RegisterKeycloakERS(srp.Config, srp.Logger, ersCache)

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -509,6 +509,9 @@ func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dp
 			return nil, nil, fmt.Errorf("invalid actor token: %w", err)
 		}
 		actorSub := actorTok.Subject()
+		if actorSub == "" {
+			return nil, nil, errors.New("actor token has no subject")
+		}
 		if actorSub != accessToken.Subject() && !actorAuthorized(accessToken, actorSub) {
 			return nil, nil, errors.New("actor not authorized for this token")
 		}

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -110,7 +110,7 @@ type Authentication struct {
 	logger *logger.Logger
 
 	// Used for testing
-	_testCheckTokenFunc func(ctx context.Context, authHeader []string, dpopInfo receiverInfo, dpopHeader []string) (jwt.Token, context.Context, error)
+	_testCheckTokenFunc func(ctx context.Context, authHeader []string, dpopInfo receiverInfo, dpopHeader []string, actorHeader []string) (jwt.Token, context.Context, error)
 }
 
 // Creates new authN which is used to verify tokens for a set of given issuers
@@ -198,6 +198,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 		}
 
 		dp := r.Header.Values("Dpop")
+		actorHdr := r.Header.Values("X-Actor-Token")
 		log := a.logger
 
 		// Verify the token
@@ -218,7 +219,7 @@ func (a Authentication) MuxHandler(handler http.Handler) http.Handler {
 		accessTok, ctx, err := a.checkToken(r.Context(), header, receiverInfo{
 			u: []string{normalizeURL(origin, r.URL)},
 			m: []string{r.Method},
-		}, dp)
+		}, dp, actorHdr)
 		if err != nil {
 			log.WarnContext(ctx,
 				"unauthenticated",
@@ -328,6 +329,7 @@ func (a Authentication) ConnectUnaryServerInterceptor() connect.UnaryInterceptor
 				header,
 				ri,
 				req.Header()["Dpop"],
+				req.Header()["X-Actor-Token"],
 			)
 			if err != nil {
 				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
@@ -459,10 +461,10 @@ func getAction(method string) string {
 }
 
 // checkToken is a helper function to verify the token.
-func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dpopInfo receiverInfo, dpopHeader []string) (jwt.Token, context.Context, error) {
+func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dpopInfo receiverInfo, dpopHeader []string, actorHeader []string) (jwt.Token, context.Context, error) {
 	// Use the test function if it is set
 	if a._testCheckTokenFunc != nil {
-		return a._testCheckTokenFunc(ctx, authHeader, dpopInfo, dpopHeader)
+		return a._testCheckTokenFunc(ctx, authHeader, dpopInfo, dpopHeader, actorHeader)
 	}
 
 	var tokenRaw string
@@ -495,11 +497,32 @@ func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dp
 		ctx = audit.ContextWithActorID(ctx, actorID)
 	}
 
+	// X-Actor-Token (spec §1 `act` rule): when present, verify it with the
+	// same token verifier used for the bearer, and require its subject to
+	// either be the bearer's own subject (self-actation) or appear in the
+	// bearer's `act` claim. An absent header leaves behavior unchanged.
+	var verifiedActorSub string
+	if len(actorHeader) > 0 && actorHeader[0] != "" {
+		actorRaw := actorHeader[0]
+		actorTok, err := a.tokenVerifier.VerifyAccessToken(ctx, actorRaw)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid actor token: %w", err)
+		}
+		actorSub := actorTok.Subject()
+		if actorSub != accessToken.Subject() && !actorAuthorized(accessToken, actorSub) {
+			return nil, nil, errors.New("actor not authorized for this token")
+		}
+		verifiedActorSub = actorSub
+	}
+
 	_, tokenHasCNF := accessToken.Get("cnf")
 	if !tokenHasCNF && !a.enforceDPoP {
 		// this condition is not quite tight because it's possible that the `cnf` claim may
 		// come from token introspection
 		ctx = ctxAuth.ContextWithAuthNInfo(ctx, nil, accessToken, tokenRaw)
+		if verifiedActorSub != "" {
+			ctx = ctxAuth.ContextWithActorSubject(ctx, verifiedActorSub)
+		}
 		return accessToken, ctx, nil
 	}
 	dpopKey, err := a.validateDPoP(accessToken, tokenRaw, dpopInfo, dpopHeader)
@@ -508,7 +531,44 @@ func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dp
 		return nil, nil, err
 	}
 	ctx = ctxAuth.ContextWithAuthNInfo(ctx, dpopKey, accessToken, tokenRaw)
+	if verifiedActorSub != "" {
+		ctx = ctxAuth.ContextWithActorSubject(ctx, verifiedActorSub)
+	}
 	return accessToken, ctx, nil
+}
+
+// actorAuthorized reports whether actorSub is permitted to act on behalf of
+// the subject of tok, per the RFC 8693-style `act` claim: a list of
+// {"sub": "..."} entries. The claim arrives via jwx's generic JSON decoding
+// as []any of map[string]any, so any other shape — missing, empty,
+// wrong-typed, or an entry with a missing/empty/non-string `sub` — is
+// treated defensively as NOT authorizing that actor.
+func actorAuthorized(tok jwt.Token, actorSub string) bool {
+	if actorSub == "" {
+		return false
+	}
+	raw, ok := tok.PrivateClaims()["act"]
+	if !ok {
+		return false
+	}
+	entries, ok := raw.([]any)
+	if !ok {
+		return false
+	}
+	for _, entry := range entries {
+		m, isMap := entry.(map[string]any)
+		if !isMap {
+			continue
+		}
+		sub, isString := m["sub"].(string)
+		if !isString || sub == "" {
+			continue
+		}
+		if sub == actorSub {
+			return true
+		}
+	}
+	return false
 }
 
 func (a Authentication) validateDPoP(accessToken jwt.Token, acessTokenRaw string, dpopInfo receiverInfo, headers []string) (jwk.Key, error) {
@@ -667,7 +727,7 @@ func (a Authentication) ipcReauthCheck(ctx context.Context, path string, header 
 			token, ctxWithJWK, err := a.checkToken(ctx, authHeader, receiverInfo{
 				u: []string{path},
 				m: []string{http.MethodPost},
-			}, header["Dpop"])
+			}, header["Dpop"], header["X-Actor-Token"])
 			if err != nil {
 				return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated"))
 			}

--- a/service/internal/auth/authn.go
+++ b/service/internal/auth/authn.go
@@ -497,10 +497,16 @@ func (a *Authentication) checkToken(ctx context.Context, authHeader []string, dp
 		ctx = audit.ContextWithActorID(ctx, actorID)
 	}
 
-	// X-Actor-Token (spec §1 `act` rule): when present, verify it with the
-	// same token verifier used for the bearer, and require its subject to
-	// either be the bearer's own subject (self-actation) or appear in the
-	// bearer's `act` claim. An absent header leaves behavior unchanged.
+	// X-Actor-Token: carries a second token identifying the effective actor
+	// making the request on behalf of the bearer token's subject (e.g. an
+	// agent acting for a person). When present, it is verified with the same
+	// token verifier used for the bearer, and its subject must either equal
+	// the bearer's own subject (self-actation) or appear in the bearer
+	// token's `act` claim (a list of {"sub": "..."} entries); an actor token
+	// with no subject, or one that fails either check, is rejected. An
+	// absent header leaves behavior unchanged. See ContextWithActorSubject
+	// (service/pkg/auth/context_auth.go) for how the verified actor subject
+	// is carried forward for audit.
 	var verifiedActorSub string
 	if len(actorHeader) > 0 && actorHeader[0] != "" {
 		actorRaw := actorHeader[0]

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -208,7 +208,7 @@ func (s *AuthSuite) Test_IPCUnaryServerInterceptor() {
 
 	type contextKey string
 	mockCtx := context.WithValue(context.Background(), contextKey("mockKey"), "mockValue")
-	s.auth._testCheckTokenFunc = func(_ context.Context, authHeader []string, _ receiverInfo, _ []string) (jwt.Token, context.Context, error) {
+	s.auth._testCheckTokenFunc = func(_ context.Context, authHeader []string, _ receiverInfo, _ []string, _ []string) (jwt.Token, context.Context, error) {
 		if len(authHeader) == 0 {
 			return nil, nil, errors.New("missing authorization header")
 		}
@@ -342,7 +342,7 @@ func (s *AuthSuite) Test_UnaryServerInterceptor_When_Authorization_Header_Missin
 }
 
 func (s *AuthSuite) Test_CheckToken_When_Authorization_Header_Invalid_Expect_Error() {
-	_, _, err := s.auth.checkToken(context.Background(), []string{"BPOP "}, receiverInfo{}, nil)
+	_, _, err := s.auth.checkToken(context.Background(), []string{"BPOP "}, receiverInfo{}, nil, nil)
 	s.Require().Error(err)
 	s.Equal("not of type bearer or dpop", err.Error())
 }
@@ -351,7 +351,7 @@ func (s *AuthSuite) Test_CheckToken_When_Valid_No_DPoP_Expect_Error() {
 	// Default suite config enforces DPoP. A bearer with no `cnf` claim
 	// should be rejected before any access decision is made.
 	bearer := s.mintCWT(map[string]any{"cid": "client1"})
-	_, _, err := s.auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil)
+	_, _, err := s.auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, nil)
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), "dpop")
 }
@@ -434,6 +434,7 @@ func (s *AuthSuite) TestInvalid_DPoP_Cases() {
 					m: []string{http.MethodPost},
 				},
 				[]string{dpopToken},
+				nil,
 			)
 
 			s.Require().Error(err)
@@ -575,7 +576,7 @@ func (s *AuthSuite) Test_Allowing_Auth_With_No_DPoP() {
 	// CWT without a `cnf` claim — enforceDPoP=false above means the
 	// middleware accepts it and proceeds with no DPoP key bound.
 	bearer := s.mintCWT(map[string]any{"cid": "client1"})
-	_, ctx, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil)
+	_, ctx, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, nil)
 	s.Require().NoError(err)
 	s.Require().Nil(ctxAuth.GetJWKFromContext(ctx, logger.CreateTestLogger()))
 }
@@ -753,4 +754,110 @@ func Test_GetClientIDFromToken(t *testing.T) {
 func (s *AuthSuite) mintCWT(custom map[string]any) string {
 	claims := standardClaims(s.server.URL, "test", "user-1", time.Hour)
 	return signCWT(s.T(), s.priv, s.kid, claims, custom)
+}
+
+// TestActorToken covers X-Actor-Token enforcement against the bearer's
+// `act` claim (identity track2 platform arkavo-ers, task 6 / spec §1 `act`
+// rule). Standalone (not a suite method) so `go test -run TestActorToken`
+// selects exactly this test and its subtests.
+func TestActorToken(t *testing.T) {
+	priv, kid := newP256(t)
+	keySetCBOR := coseKeySetFromPub(t, &priv.PublicKey, kid)
+
+	// Fake IdP serving OIDC discovery + the COSE Key Set, mirroring
+	// AuthSuite.SetupTest. Declared as a var so the handler closure can
+	// reference srv.URL once it's assigned (no request arrives before then).
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w,
+				`{"issuer":%q,"jwks_uri":%q,"cose_keys_uri":%q}`,
+				srv.URL, srv.URL+"/jwks", srv.URL+"/cose-keys")
+		case "/cose-keys":
+			w.Header().Set("Content-Type", "application/cose-key-set+cbor")
+			_, _ = w.Write(keySetCBOR)
+		case "/jwks":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"keys":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	auth, err := NewAuthenticator(
+		context.Background(),
+		Config{
+			AuthNConfig: AuthNConfig{
+				EnforceDPoP: false,
+				Issuer:      srv.URL,
+				Audience:    "test",
+			},
+		},
+		logger.CreateTestLogger(),
+		func(_ string, _ any) error { return nil },
+	)
+	require.NoError(t, err)
+
+	// mint signs a CWT with the given subject and custom text-label claims,
+	// using the key the fake IdP's COSE Key Set advertises.
+	mint := func(sub string, custom map[string]any) string {
+		return signCWT(t, priv, kid, standardClaims(srv.URL, "test", sub, time.Hour), custom)
+	}
+
+	t.Run("actor authorized via bearer's act claim passes and is recorded in context", func(t *testing.T) {
+		bearer := mint("user-1", map[string]any{
+			"act": []any{map[string]any{"sub": "https://arks.test"}},
+		})
+		actorTok := mint("https://arks.test", nil)
+
+		_, ctx, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{actorTok})
+		require.NoError(t, err)
+		assert.Equal(t, "https://arks.test", ctxAuth.GetActorSubjectFromContext(ctx))
+	})
+
+	t.Run("actor not listed in act claim is rejected", func(t *testing.T) {
+		bearer := mint("user-1", nil) // no `act` claim at all
+		actorTok := mint("https://arks.test", nil)
+
+		_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{actorTok})
+		require.Error(t, err)
+	})
+
+	t.Run("actor token failing verification is rejected", func(t *testing.T) {
+		bearer := mint("user-1", map[string]any{
+			"act": []any{map[string]any{"sub": "https://arks.test"}},
+		})
+
+		t.Run("garbage token", func(t *testing.T) {
+			_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{"not-a-cwt"})
+			require.Error(t, err)
+		})
+
+		t.Run("wrong signing key", func(t *testing.T) {
+			otherPriv, otherKid := newP256(t) // not in the fake IdP's published key set
+			badActorTok := signCWT(t, otherPriv, otherKid, standardClaims(srv.URL, "test", "https://arks.test", time.Hour), nil)
+			_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{badActorTok})
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("no actor header behaves exactly as before", func(t *testing.T) {
+		bearer := mint("user-1", nil)
+
+		_, ctx, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, ctxAuth.GetActorSubjectFromContext(ctx))
+	})
+
+	t.Run("actor whose sub equals the bearer's own sub passes without an act claim", func(t *testing.T) {
+		bearer := mint("user-1", nil) // no `act` claim
+		actorTok := mint("user-1", nil)
+
+		_, ctx, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{actorTok})
+		require.NoError(t, err)
+		assert.Equal(t, "user-1", ctxAuth.GetActorSubjectFromContext(ctx))
+	})
 }

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -823,7 +823,7 @@ func TestActorToken(t *testing.T) {
 		actorTok := mint("https://arks.test", nil)
 
 		_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{actorTok})
-		require.Error(t, err)
+		require.ErrorContains(t, err, "actor not authorized")
 	})
 
 	t.Run("actor token failing verification is rejected", func(t *testing.T) {
@@ -833,15 +833,25 @@ func TestActorToken(t *testing.T) {
 
 		t.Run("garbage token", func(t *testing.T) {
 			_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{"not-a-cwt"})
-			require.Error(t, err)
+			require.ErrorContains(t, err, "invalid actor token")
 		})
 
 		t.Run("wrong signing key", func(t *testing.T) {
 			otherPriv, otherKid := newP256(t) // not in the fake IdP's published key set
 			badActorTok := signCWT(t, otherPriv, otherKid, standardClaims(srv.URL, "test", "https://arks.test", time.Hour), nil)
 			_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{badActorTok})
-			require.Error(t, err)
+			require.ErrorContains(t, err, "invalid actor token")
 		})
+	})
+
+	t.Run("actor token with no subject is rejected even when bearer also has no subject", func(t *testing.T) {
+		// Regression case: accessToken.Subject() == "" and actorTok.Subject() == ""
+		// must NOT short-circuit the authorization check via "" != "" being false.
+		bearer := mint("", nil)   // bearer with no `sub`
+		actorTok := mint("", nil) // actor with no `sub`
+
+		_, _, err := auth.checkToken(context.Background(), []string{"Bearer " + bearer}, receiverInfo{}, nil, []string{actorTok})
+		require.ErrorContains(t, err, "actor token has no subject")
 	})
 
 	t.Run("no actor header behaves exactly as before", func(t *testing.T) {
@@ -860,4 +870,36 @@ func TestActorToken(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "user-1", ctxAuth.GetActorSubjectFromContext(ctx))
 	})
+}
+
+// TestActorAuthorized pins actorAuthorized's fail-closed contract directly:
+// every malformed/absent shape of the `act` claim must resolve to NOT
+// authorized, and only a well-formed {"sub": <matching string>} entry
+// authorizes. See task-6 fix round 1, finding 2.
+func TestActorAuthorized(t *testing.T) {
+	const wantSub = "https://arks.test"
+
+	tests := []struct {
+		name string
+		act  any // nil means the `act` claim is not set at all
+		want bool
+	}{
+		{"claim absent", nil, false},
+		{"non-array act claim (bare string)", wantSub, false},
+		{"array entry is not a map", []any{"notamap"}, false},
+		{"map entry missing sub", []any{map[string]any{"other": "x"}}, false},
+		{"map entry sub wrong type", []any{map[string]any{"sub": 42}}, false},
+		{"map entry sub is empty string", []any{map[string]any{"sub": ""}}, false},
+		{"well-formed entry matches", []any{map[string]any{"sub": wantSub}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok := jwt.New()
+			if tt.act != nil {
+				require.NoError(t, tok.Set("act", tt.act))
+			}
+			assert.Equal(t, tt.want, actorAuthorized(tok, wantSub))
+		})
+	}
 }

--- a/service/internal/auth/authn_test.go
+++ b/service/internal/auth/authn_test.go
@@ -757,9 +757,8 @@ func (s *AuthSuite) mintCWT(custom map[string]any) string {
 }
 
 // TestActorToken covers X-Actor-Token enforcement against the bearer's
-// `act` claim (identity track2 platform arkavo-ers, task 6 / spec §1 `act`
-// rule). Standalone (not a suite method) so `go test -run TestActorToken`
-// selects exactly this test and its subtests.
+// `act` claim. Standalone (not a suite method) so `go test -run
+// TestActorToken` selects exactly this test and its subtests.
 func TestActorToken(t *testing.T) {
 	priv, kid := newP256(t)
 	keySetCBOR := coseKeySetFromPub(t, &priv.PublicKey, kid)
@@ -875,7 +874,7 @@ func TestActorToken(t *testing.T) {
 // TestActorAuthorized pins actorAuthorized's fail-closed contract directly:
 // every malformed/absent shape of the `act` claim must resolve to NOT
 // authorized, and only a well-formed {"sub": <matching string>} entry
-// authorizes. See task-6 fix round 1, finding 2.
+// authorizes.
 func TestActorAuthorized(t *testing.T) {
 	const wantSub = "https://arks.test"
 

--- a/service/internal/auth/cwt_verifier.go
+++ b/service/internal/auth/cwt_verifier.go
@@ -157,16 +157,18 @@ func (v *CWTVerifier) VerifyAccessToken(ctx context.Context, tokenRaw string) (j
 }
 
 // decodeSign1FromToken base64-decodes tokenRaw and parses the result as a
-// COSE_Sign1 message, WITHOUT verifying its signature. It accepts
-// base64url (raw, or padded — some clients pad) of either a CBOR-tagged
-// (#61 CWT wrapper around a tagged #18 COSE_Sign1) or untagged COSE_Sign1.
+// COSE_Sign1 message, WITHOUT verifying its signature. It accepts unpadded
+// base64url (RFC 4648 §5), falling back to padded standard base64
+// (RFC 4648 §4) for clients that pad; it does not accept padded base64url.
+// The decoded bytes may hold either a CBOR-tagged (#61 CWT wrapper around a
+// tagged #18 COSE_Sign1) or untagged COSE_Sign1.
 func decodeSign1FromToken(tokenRaw string) (*cose.Sign1Message, error) {
 	raw, err := base64.RawURLEncoding.DecodeString(tokenRaw)
 	if err != nil {
 		// Some clients pad. Accept either form.
 		raw, err = base64.StdEncoding.DecodeString(tokenRaw)
 		if err != nil {
-			return nil, fmt.Errorf("cwt: subject_token is not valid base64url: %w", err)
+			return nil, fmt.Errorf("cwt: token is not valid base64: %w", err)
 		}
 	}
 

--- a/service/internal/auth/cwt_verifier.go
+++ b/service/internal/auth/cwt_verifier.go
@@ -156,16 +156,17 @@ func (v *CWTVerifier) VerifyAccessToken(ctx context.Context, tokenRaw string) (j
 	return tok, err
 }
 
-// VerifyCWTSubjectToken verifies the base64url-encoded CWT and returns the
-// verified claims as both a jwt.Token (for direct use) and an unsigned-JWT
-// string (for the claims-mode ERS).
-func (v *CWTVerifier) VerifyCWTSubjectToken(ctx context.Context, subjectToken string) (jwt.Token, string, error) {
-	raw, err := base64.RawURLEncoding.DecodeString(subjectToken)
+// decodeSign1FromToken base64-decodes tokenRaw and parses the result as a
+// COSE_Sign1 message, WITHOUT verifying its signature. It accepts
+// base64url (raw, or padded — some clients pad) of either a CBOR-tagged
+// (#61 CWT wrapper around a tagged #18 COSE_Sign1) or untagged COSE_Sign1.
+func decodeSign1FromToken(tokenRaw string) (*cose.Sign1Message, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(tokenRaw)
 	if err != nil {
 		// Some clients pad. Accept either form.
-		raw, err = base64.StdEncoding.DecodeString(subjectToken)
+		raw, err = base64.StdEncoding.DecodeString(tokenRaw)
 		if err != nil {
-			return nil, "", fmt.Errorf("cwt: subject_token is not valid base64url: %w", err)
+			return nil, fmt.Errorf("cwt: subject_token is not valid base64url: %w", err)
 		}
 	}
 
@@ -185,9 +186,20 @@ func (v *CWTVerifier) VerifyCWTSubjectToken(ctx context.Context, subjectToken st
 	if err := msg.UnmarshalCBOR(raw); err != nil {
 		var untagged cose.UntaggedSign1Message
 		if uErr := untagged.UnmarshalCBOR(raw); uErr != nil {
-			return nil, "", fmt.Errorf("cwt: not a COSE_Sign1 (tagged: %v; untagged: %w)", err, uErr)
+			return nil, fmt.Errorf("cwt: not a COSE_Sign1 (tagged: %w; untagged: %w)", err, uErr)
 		}
 		msg = cose.Sign1Message(untagged)
+	}
+	return &msg, nil
+}
+
+// VerifyCWTSubjectToken verifies the base64url-encoded CWT and returns the
+// verified claims as both a jwt.Token (for direct use) and an unsigned-JWT
+// string (for the claims-mode ERS).
+func (v *CWTVerifier) VerifyCWTSubjectToken(ctx context.Context, subjectToken string) (jwt.Token, string, error) {
+	msg, err := decodeSign1FromToken(subjectToken)
+	if err != nil {
+		return nil, "", err
 	}
 
 	keys, err := v.keys(ctx)
@@ -348,6 +360,22 @@ func decodeCWTClaims(payload []byte) (map[string]any, error) {
 		}
 	}
 	return out, nil
+}
+
+// DecodeCWTClaimsFromToken decodes the claims of a base64url-encoded CWT
+// WITHOUT verifying its signature. It exists for consumers that receive a
+// token already verified upstream by the auth interceptor (the ERS on the
+// with_request_token path receives the raw CWT, not the unsigned-JWT bridge).
+// Never use it as an authentication step.
+func DecodeCWTClaimsFromToken(tokenRaw string) (map[string]any, error) {
+	msg, err := decodeSign1FromToken(tokenRaw)
+	if err != nil {
+		return nil, err
+	}
+	if len(msg.Payload) == 0 {
+		return nil, errors.New("cwt: empty payload")
+	}
+	return decodeCWTClaims(msg.Payload)
 }
 
 // cwtIntLabelToName maps CWT integer claim labels (RFC 8392 §4) to JWT

--- a/service/internal/auth/cwt_verifier_test.go
+++ b/service/internal/auth/cwt_verifier_test.go
@@ -333,3 +333,30 @@ func TestNewCWTVerifier_RejectsBadConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeCWTClaimsFromToken_ParseOnly(t *testing.T) {
+	priv, kid := newP256(t)
+	tokenRaw := signCWT(t, priv, kid,
+		map[int64]any{
+			1: "https://identity.arkavo.net",
+			2: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+			3: []any{"https://platform.arkavo.net"},
+			4: int64(4102444800),
+			6: int64(1700000000),
+		},
+		map[string]any{
+			"arkavo_entitlements": []any{"https://arkavo.ai/attr/tdf/value/decrypt"},
+			"arkavo_npe":          map[any]any{"type": "agent", "depth": uint64(0)},
+		},
+	)
+
+	claims, err := DecodeCWTClaimsFromToken(tokenRaw)
+	require.NoError(t, err)
+	assert.Equal(t, "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK", claims["sub"])
+
+	npe, _ := claims["arkavo_npe"].(map[string]any)
+	assert.Equal(t, "agent", npe["type"])
+
+	_, err = DecodeCWTClaimsFromToken("not-a-cwt")
+	require.Error(t, err)
+}

--- a/service/internal/auth/cwt_verifier_test.go
+++ b/service/internal/auth/cwt_verifier_test.go
@@ -101,10 +101,9 @@ func keySetServer(t *testing.T, body []byte) *httptest.Server {
 
 // standardClaims builds a CWT claims map with CBOR integer labels
 // (RFC 8392 §4) for the standard registered claims used in tests.
-// `sub` is parameterized for future tests even though every existing test
-// uses "user-1".
-//
-//nolint:unparam // sub is intentionally parameterizable
+// `sub` is parameterized so callers can mint tokens for distinct subjects
+// (e.g. TestActorToken in authn_test.go mints bearer and actor CWTs with
+// different subjects).
 func standardClaims(iss, aud, sub string, ttl time.Duration) map[int64]any {
 	now := time.Now().Unix()
 	return map[int64]any{

--- a/service/pkg/auth/context_auth.go
+++ b/service/pkg/auth/context_auth.go
@@ -30,6 +30,34 @@ type authContext struct {
 	rawToken    string
 }
 
+// actorSubjectContextKey is a distinct, unexported context key type for the
+// verified X-Actor-Token subject. Kept separate from authContext (rather
+// than widening it) because authContext's constructor signature is
+// exercised directly by tests in this package and by
+// service/kas/access/rewrap_test.go and
+// service/internal/auth/authn_ipc_metadata_interceptor_test.go.
+type actorSubjectContextKey struct{}
+
+var actorSubjectKey = actorSubjectContextKey{}
+
+// ContextWithActorSubject stores the verified subject of an X-Actor-Token
+// presented alongside the bearer token, for audit purposes. checkToken
+// calls this on the success path only after verifying the actor token's
+// signature and confirming it is authorized to act on behalf of the
+// bearer's subject (self-actation, or listed in the bearer's `act` claim).
+func ContextWithActorSubject(ctx context.Context, actor string) context.Context {
+	return context.WithValue(ctx, actorSubjectKey, actor)
+}
+
+// GetActorSubjectFromContext returns the verified actor subject stored by
+// ContextWithActorSubject, or "" if no actor token was presented/verified.
+func GetActorSubjectFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(actorSubjectKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
 func ContextWithAuthNInfo(ctx context.Context, key jwk.Key, accessToken jwt.Token, raw string) context.Context {
 	return context.WithValue(ctx, authnContextKey, &authContext{
 		key,

--- a/service/policy/filestore/arkavo_decision_test.go
+++ b/service/policy/filestore/arkavo_decision_test.go
@@ -1,0 +1,134 @@
+package filestore_test
+
+import (
+	"context"
+	"testing"
+
+	authz "github.com/opentdf/platform/protocol/go/authorization/v2"
+	entityresolutionV2 "github.com/opentdf/platform/protocol/go/entityresolution/v2"
+	"github.com/opentdf/platform/protocol/go/policy"
+	access "github.com/opentdf/platform/service/internal/access/v2"
+	"github.com/opentdf/platform/service/logger"
+	"github.com/opentdf/platform/service/policy/filestore"
+)
+
+// TestArkavoSnapshot_DirectEntitlementDecisions proves that the arkavo ERS
+// provider's direct-entitlement shape (attribute-value FQNs on
+// EntityRepresentation.DirectEntitlements) and the file-backed arkavo.ai
+// policy snapshot (examples/config/policy.arkavo.yaml) compose correctly
+// through the real v2 PolicyDecisionPoint: no subject mappings are involved,
+// only direct entitlements, and the classification attribute's hierarchy
+// rule must rank a device's held value against the resource's required
+// value rather than treating any held value as sufficient.
+func TestArkavoSnapshot_DirectEntitlementDecisions(t *testing.T) {
+	ctx := context.Background()
+	log := logger.CreateTestLogger()
+
+	store, err := filestore.NewStoreFromFile("../../../examples/config/policy.arkavo.yaml")
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+
+	allAttrs, err := store.ListAllAttributes(ctx)
+	if err != nil {
+		t.Fatalf("ListAllAttributes: %v", err)
+	}
+	allSMs, err := store.ListAllSubjectMappings(ctx)
+	if err != nil {
+		t.Fatalf("ListAllSubjectMappings: %v", err)
+	}
+	allRRs, err := store.ListAllRegisteredResources(ctx)
+	if err != nil {
+		t.Fatalf("ListAllRegisteredResources: %v", err)
+	}
+
+	pdp, err := access.NewPolicyDecisionPoint(ctx, log, allAttrs, allSMs, allRRs, true, false)
+	if err != nil {
+		t.Fatalf("NewPolicyDecisionPoint: %v", err)
+	}
+	if pdp == nil {
+		t.Fatal("nil PDP")
+	}
+
+	// FQNs confirmed against examples/config/policy.arkavo.yaml: namespace
+	// arkavo.ai, attribute `tdf` (anyOf: create, decrypt) and attribute
+	// `classification` (hierarchy, declared highest-first: restricted,
+	// confidential, internal, public).
+	const (
+		tdfDecrypt        = "https://arkavo.ai/attr/tdf/value/decrypt"
+		tdfCreate         = "https://arkavo.ai/attr/tdf/value/create"
+		classInternal     = "https://arkavo.ai/attr/classification/value/internal"
+		classConfidential = "https://arkavo.ai/attr/classification/value/confidential"
+	)
+
+	agent := &entityresolutionV2.EntityRepresentation{
+		OriginalId: "agent",
+		DirectEntitlements: []*entityresolutionV2.DirectEntitlement{
+			{AttributeValueFqn: tdfDecrypt, Actions: []string{"read"}},
+		},
+	}
+	device := &entityresolutionV2.EntityRepresentation{
+		OriginalId: "device",
+		DirectEntitlements: []*entityresolutionV2.DirectEntitlement{
+			{AttributeValueFqn: classInternal, Actions: []string{"read"}},
+		},
+	}
+
+	read := &policy.Action{Name: "read"}
+
+	res := func(fqns ...string) *authz.Resource {
+		return &authz.Resource{
+			Resource: &authz.Resource_AttributeValues_{
+				AttributeValues: &authz.Resource_AttributeValues{Fqns: fqns},
+			},
+		}
+	}
+
+	// Agent's only direct entitlement is tdf/decrypt for the read action, so
+	// a resource tagged tdf/decrypt must be permitted...
+	assertDecision(ctx, t, pdp, agent, read, res(tdfDecrypt), true,
+		"agent entitled to tdf/decrypt should be permitted to read a tdf/decrypt-tagged resource")
+	// ...while a resource tagged tdf/create carries no matching entitlement,
+	// so it must be denied.
+	assertDecision(ctx, t, pdp, agent, read, res(tdfCreate), false,
+		"agent without a tdf/create entitlement should be denied read on a tdf/create-tagged resource")
+
+	// Device's direct entitlement is classification/internal. A resource
+	// requiring exactly that value must be permitted...
+	assertDecision(ctx, t, pdp, device, read, res(classInternal), true,
+		"device entitled to classification/internal should be permitted to read an internal resource")
+	// ...but classification is a HIERARCHY ranked by declaration index, and
+	// confidential (index 1) outranks internal (index 2). A device holding
+	// only internal must therefore be denied a confidential resource: this
+	// is the direction the hierarchy rule exists to enforce, and getting it
+	// backwards (denying the lower-ranked resource instead) would make the
+	// hierarchy check vacuous.
+	assertDecision(ctx, t, pdp, device, read, res(classConfidential), false,
+		"device entitled only to classification/internal must be denied read on a higher-ranked confidential resource")
+}
+
+// assertDecision runs pdp.GetDecision for the given entity, action, and
+// single resource and asserts Decision.AllPermitted matches wantPermit.
+func assertDecision(
+	ctx context.Context,
+	t *testing.T,
+	pdp *access.PolicyDecisionPoint,
+	entity *entityresolutionV2.EntityRepresentation,
+	action *policy.Action,
+	resource *authz.Resource,
+	wantPermit bool,
+	msg string,
+) {
+	t.Helper()
+
+	decision, _, err := pdp.GetDecision(ctx, entity, action, []*authz.Resource{resource})
+	if err != nil {
+		t.Fatalf("GetDecision: %v", err)
+	}
+	if decision == nil {
+		t.Fatal("GetDecision returned nil decision")
+	}
+	if decision.AllPermitted != wantPermit {
+		t.Errorf("%s: Decision.AllPermitted = %v, want %v", msg, decision.AllPermitted, wantPermit)
+	}
+}


### PR DESCRIPTION
Adds an opt-in `mode: arkavo` Entity Resolution Service that turns an authnz-rs CWT (or its unsigned-JWT bridge) into platform entities and direct entitlements, plus the platform half of the spec's `act` delegation rule.

Implements `docs/superpowers/specs/2026-08-27-identity-plane-end-state-design.md` §1 (`act` rule, platform side), §2.2, §3 (platform rows), §5.1 (platform tests), §5.2 step 2.

## What's in it

**New provider `service/entityresolution/arkavo/v2`** — modeled on `patreon/v2` (same registration, config, tracer and test conventions), wired behind `mode: arkavo` in `service/entityresolution/v2/entity_resolution.go`. Existing modes are untouched.

- **PE → `SUBJECT` entity**: `sub` plus `iss`, the account id, and (when trusted) the materialized claims. Agent tokens are evaluated as their own subject.
- **NPE → `ENVIRONMENT` entity**: agent/device NPEs are emitted as a `ClientId` environment entity — audited, never evaluated, never authorization-bearing.
- **Direct entitlements**: `arkavo_entitlements` values are emitted as `DirectEntitlement`s with a configurable lowercase action set (default `["read"]`).
- **Device class ceilings**: a configurable class → attribute-FQN table adds a ceiling entitlement for device NPEs.
- **No subject mappings.** Claims pass through verbatim via `AdditionalProps`; the file-backed policy snapshot carries vocabulary only.

**Format-tolerant token parsing** — the ERS tries a JOSE parse first and falls back to base64url + CBOR COSE_Sign1 decoding, because the `with_request_token` decision path hands the ERS a raw CWT rather than a JWT. This required exporting a parse-only decoder, `auth.DecodeCWTClaimsFromToken`, from `service/internal/auth/cwt_verifier.go`. **It does not verify the signature** — it is for post-verification consumers only, and says so in its doc comment. The existing verifying path was refactored to share the same decode helper rather than duplicating it.

**Trust model (two paths, both gated).** Entitlements and NPE claims are honored only when `trust_materialized_claims: true` **and** the token `iss` equals `trusted_issuer`; untrusted tokens resolve with zero entitlements and their NPE claims dropped. `ResolveEntities` accepts caller-supplied `Entity_Claims` where the issuer comparison cannot be redone, so it re-asserts the operator's master switch alongside the `arkavo_trusted` marker that carries the earlier decision forward. Both paths are documented in `service/entityresolution/arkavo/v2/README.md`, including the PEP-boundary caveat.

**Platform-side `X-Actor-Token` enforcement** (`service/internal/auth/authn.go`) — when the header is present, the actor token is verified and its subject must match the bearer token's `act` claim. Fail-closed: an actor token with no `sub` is rejected rather than passing through the self-actation comparison. Covers the DPoP path as well as plain Bearer.

**Config and policy examples** — `examples/config/policy.arkavo.yaml` (namespace `arkavo.ai`: `tdf`, `action`, `mesh` anyOf attributes and a `classification` hierarchy) and `examples/config/opentdf-arkavo-local-test.yaml`.

## Ordering rule worth knowing

`classification` HIERARCHY values must be declared **highest-first** (`restricted, confidential, internal, public`) — the PDP ranks by declaration index, lowest index = highest rank (`service/internal/access/v2/evaluate.go`). `policy.arkavo.yaml` follows this.

**`examples/config/policy.patreon.yaml` does not** — it declares `public, member, paid, vip`, i.e. lowest-first, so `public` currently outranks `vip`. That is a pre-existing bug in a file this branch does not touch; it is filed as a separate follow-up rather than fixed here, to keep the diff scoped.

## Testing

- Unit tests for config defaults, claims parsing (both wire formats), entity shapes, the trust gate, direct entitlements, class ceilings, and CBOR value sanitization for `structpb`.
- A CWT/JWT equivalence test asserting both wire formats resolve to the same entities.
- A decision test (`service/policy/filestore/arkavo_decision_test.go`) driving a real PDP built from `policy.arkavo.yaml`: agent permitted on `tdf/decrypt` and denied on `tdf/create`; device permitted at `classification/internal` and denied at `classification/confidential` (hierarchy exercised in the non-trivial direction).
- `X-Actor-Token`: a table test over the authorization helper's defensive branches plus end-to-end cases through genuinely minted CWTs.

Verified on the branch: `go test ./... -short -race` passes for every package (`service/integration` needs Docker/testcontainers, unavailable in the dev environment, and is untouched by this branch); `golangci-lint run -c ../.golangci.yaml` reports 0 issues across every package this branch touches; `go mod tidy` and `go fmt ./...` produce no diff.

## Not in scope

Deferred review findings — extra test coverage, `attestation_expiry` enforcement, `direct_entitlement_actions` validation, the CORS default header list, and the `policy.patreon.yaml` hierarchy inversion — are tracked in arkavo-org/opentdf-platform#34 rather than expanding this PR.

Draft: opened for review, not for merge.
